### PR TITLE
ci: CI에 테스트 분리 + JaCoCo 커버리지 + Codecov 업로드

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -20,8 +20,31 @@ jobs:
       - name: Setup Gradle
         uses: gradle/actions/setup-gradle@v4
 
-      - name: Build
-        run: ./gradlew build --no-daemon
+      - name: Test
+        run: ./gradlew test --no-daemon
+
+      - name: JaCoCo coverage report
+        run: ./gradlew jacocoTestReport --no-daemon
+
+      - name: Build (skip tests — already executed)
+        run: ./gradlew build -x test --no-daemon
+
+      - name: Upload coverage to Codecov
+        uses: codecov/codecov-action@v4
+        with:
+          files: build/reports/jacoco/test/jacocoTestReport.xml
+          token: ${{ secrets.CODECOV_TOKEN }}
+          fail_ci_if_error: false
+          flags: unittests
+          name: codecov-backend
+
+      - name: Upload coverage HTML report
+        if: always()
+        uses: actions/upload-artifact@v4
+        with:
+          name: jacoco-html
+          path: build/reports/jacoco/test/html
+          if-no-files-found: ignore
 
       - name: Upload test report on failure
         if: failure()

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -6,7 +6,8 @@ on:
     branches: [main]
 
 jobs:
-  build:
+  test:
+    name: Test + Coverage
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v4
@@ -20,14 +21,11 @@ jobs:
       - name: Setup Gradle
         uses: gradle/actions/setup-gradle@v4
 
-      - name: Test
+      - name: Run unit tests
         run: ./gradlew test --no-daemon
 
       - name: JaCoCo coverage report
         run: ./gradlew jacocoTestReport --no-daemon
-
-      - name: Build (skip tests — already executed)
-        run: ./gradlew build -x test --no-daemon
 
       - name: Upload coverage to Codecov
         uses: codecov/codecov-action@v4
@@ -38,7 +36,7 @@ jobs:
           flags: unittests
           name: codecov-backend
 
-      - name: Upload coverage HTML report
+      - name: Upload JaCoCo HTML report
         if: always()
         uses: actions/upload-artifact@v4
         with:
@@ -52,3 +50,21 @@ jobs:
         with:
           name: test-report
           path: build/reports/tests/test
+
+  build:
+    name: Build (no tests)
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+
+      - name: Set up JDK 21
+        uses: actions/setup-java@v4
+        with:
+          distribution: temurin
+          java-version: "21"
+
+      - name: Setup Gradle
+        uses: gradle/actions/setup-gradle@v4
+
+      - name: Build (skip tests — covered by test job)
+        run: ./gradlew build -x test --no-daemon

--- a/build.gradle.kts
+++ b/build.gradle.kts
@@ -1,5 +1,6 @@
 plugins {
     java
+    jacoco
     id("org.springframework.boot") version "3.3.5"
     id("io.spring.dependency-management") version "1.1.6"
 }
@@ -41,5 +42,18 @@ tasks.withType<Test> {
         if (!project.hasProperty("includePlaywright")) {
             excludeTags("playwright")
         }
+    }
+    finalizedBy(tasks.jacocoTestReport)
+}
+
+jacoco {
+    toolVersion = "0.8.12"
+}
+
+tasks.jacocoTestReport {
+    dependsOn(tasks.test)
+    reports {
+        xml.required.set(true)
+        html.required.set(true)
     }
 }


### PR DESCRIPTION
## Summary
- CI 파이프라인에 **명시적 test 스텝**을 추가해 로그 가독성 개선 (기존엔 `./gradlew build`에 포함되어 가려짐)
- **JaCoCo** 플러그인으로 코드 커버리지 리포트(XML+HTML) 자동 생성
- **Codecov** 업로드로 커버리지 추적·배지·PR 코멘트 자동화

## 변경 내역

### `build.gradle.kts`
- \`jacoco\` 플러그인 추가 (toolVersion 0.8.12)
- Test 태스크에 \`finalizedBy(tasks.jacocoTestReport)\` → 테스트 직후 자동 리포트 생성
- \`jacocoTestReport\`의 XML·HTML 리포트 활성화

### \`.github/workflows/ci.yml\`
- 단일 \`Build\` 스텝 → \`Test\` / \`JaCoCo coverage report\` / \`Build (skip tests)\` 로 분리
- \`codecov/codecov-action@v4\` 로 \`build/reports/jacoco/test/jacocoTestReport.xml\` 업로드
  - \`CODECOV_TOKEN\` secret 사용 (private repo 대응; public repo는 토큰 없이도 업로드 가능하므로 \`fail_ci_if_error: false\`)
  - \`flags: unittests\` 로 향후 다른 잡(integration/e2e) 분리 시 구분 가능
- 성공/실패 관계없이 \`jacoco-html\` 아티팩트로 HTML 리포트 보관

## Test plan
- [x] 로컬 \`./gradlew clean test\` → \`build/reports/jacoco/test/jacocoTestReport.xml\` 생성 확인
- [ ] CI 초록불 (PR 후 즉시 확인)
- [ ] Codecov 업로드 성공 (저장소를 codecov.io에서 활성화한 뒤 확인)

## 설정 안내 (저장소 소유자)
1. https://app.codecov.io 로 저장소 등록 (GitHub OAuth 연동)
2. **Private repo**라면 Settings → Repository Secrets 에 \`CODECOV_TOKEN\` 추가
   - Public repo면 토큰 없어도 tokenless 업로드 동작
3. 머지 후 README에 배지 추가:
   \`\`\`md
   [![codecov](https://codecov.io/gh/marcosdeseul/dihisoft-claude-session/branch/main/graph/badge.svg)](https://codecov.io/gh/marcosdeseul/dihisoft-claude-session)
   \`\`\`

## 범위 밖
- 커버리지 임계치 강제 (\`jacocoTestCoverageVerification\`) — 후속 이슈로 분리
- 통합 테스트/E2E 별도 리포팅 — 2.2 / 4.0에서 도입 검토

🤖 Generated with [Claude Code](https://claude.com/claude-code)