### PR TITLE
ci: JaCoCo 커버리지 95% 임계치 강제 — **의도된 실패 PR**

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -28,6 +28,7 @@ jobs:
         run: ./gradlew jacocoTestReport --no-daemon
 
       - name: Upload coverage to Codecov
+        if: always()
         uses: codecov/codecov-action@v4
         with:
           files: build/reports/jacoco/test/jacocoTestReport.xml
@@ -43,6 +44,9 @@ jobs:
           name: jacoco-html
           path: build/reports/jacoco/test/html
           if-no-files-found: ignore
+
+      - name: Verify coverage threshold (95% INSTRUCTION)
+        run: ./gradlew jacocoTestCoverageVerification --no-daemon
 
       - name: Upload test report on failure
         if: failure()

--- a/build.gradle.kts
+++ b/build.gradle.kts
@@ -57,3 +57,16 @@ tasks.jacocoTestReport {
         html.required.set(true)
     }
 }
+
+tasks.jacocoTestCoverageVerification {
+    dependsOn(tasks.test)
+    violationRules {
+        rule {
+            limit {
+                counter = "INSTRUCTION"
+                value = "COVEREDRATIO"
+                minimum = "0.95".toBigDecimal()
+            }
+        }
+    }
+}

--- a/src/test/java/com/example/board/config/RestAccessDeniedHandlerTest.java
+++ b/src/test/java/com/example/board/config/RestAccessDeniedHandlerTest.java
@@ -1,0 +1,36 @@
+package com.example.board.config;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+import com.fasterxml.jackson.databind.ObjectMapper;
+import com.fasterxml.jackson.datatype.jsr310.JavaTimeModule;
+import org.junit.jupiter.api.Test;
+import org.springframework.mock.web.MockHttpServletRequest;
+import org.springframework.mock.web.MockHttpServletResponse;
+import org.springframework.security.access.AccessDeniedException;
+
+class RestAccessDeniedHandlerTest {
+
+    private final ObjectMapper objectMapper =
+            new ObjectMapper().registerModule(new JavaTimeModule());
+
+    @Test
+    void 핸들러가_호출되면_403과_ErrorResponse_JSON을_기록한다() throws Exception {
+        RestAccessDeniedHandler handler = new RestAccessDeniedHandler(objectMapper);
+        MockHttpServletRequest request = new MockHttpServletRequest("GET", "/api/some");
+        MockHttpServletResponse response = new MockHttpServletResponse();
+
+        handler.handle(request, response, new AccessDeniedException("거부"));
+
+        assertThat(response.getStatus()).isEqualTo(403);
+        assertThat(response.getContentType()).contains("application/json");
+        assertThat(response.getCharacterEncoding()).isEqualToIgnoringCase("UTF-8");
+
+        String body = response.getContentAsString();
+        assertThat(body).contains("\"status\":403");
+        assertThat(body).contains("\"error\":\"Forbidden\"");
+        assertThat(body).contains("\"message\":\"접근이 거부되었습니다\"");
+        assertThat(body).contains("\"path\":\"/api/some\"");
+        assertThat(body).contains("\"timestamp\"");
+    }
+}

--- a/src/test/java/com/example/board/user/AuthServiceTest.java
+++ b/src/test/java/com/example/board/user/AuthServiceTest.java
@@ -1,0 +1,71 @@
+package com.example.board.user;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.assertj.core.api.Assertions.assertThatThrownBy;
+
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.boot.test.context.SpringBootTest;
+import org.springframework.test.context.ActiveProfiles;
+
+@SpringBootTest
+@ActiveProfiles("test")
+class AuthServiceTest {
+
+    @Autowired
+    AuthService authService;
+
+    @Autowired
+    UserRepository userRepository;
+
+    @BeforeEach
+    void cleanDb() {
+        userRepository.deleteAll();
+    }
+
+    @Test
+    void signup_정상입력시_User를_저장하고_password는_해시된다() {
+        User saved = authService.signup(new SignupRequest("alice_srv", "pw12345"));
+
+        assertThat(saved.getId()).isNotNull();
+        assertThat(saved.getUsername()).isEqualTo("alice_srv");
+        assertThat(saved.getPassword()).isNotEqualTo("pw12345");
+        assertThat(saved.getPassword()).startsWith("$2");
+    }
+
+    @Test
+    void signup_username이_null이면_IllegalArgumentException이_발생한다() {
+        SignupRequest request = new SignupRequest(null, "pw12345");
+
+        assertThatThrownBy(() -> authService.signup(request))
+                .isInstanceOf(IllegalArgumentException.class)
+                .hasMessageContaining("필수");
+    }
+
+    @Test
+    void signup_username이_공백만이면_trim_후_IllegalArgumentException이_발생한다() {
+        SignupRequest request = new SignupRequest("   ", "pw12345");
+
+        assertThatThrownBy(() -> authService.signup(request))
+                .isInstanceOf(IllegalArgumentException.class)
+                .hasMessageContaining("필수");
+    }
+
+    @Test
+    void signup_동일한_username이면_중복_메시지와_함께_IllegalArgumentException이_발생한다() {
+        authService.signup(new SignupRequest("dup_srv", "pw12345"));
+
+        assertThatThrownBy(() -> authService.signup(new SignupRequest("dup_srv", "other99")))
+                .isInstanceOf(IllegalArgumentException.class)
+                .hasMessageContaining("이미")
+                .hasMessageContaining("dup_srv");
+    }
+
+    @Test
+    void signup_username이_trim되어_저장된다() {
+        User saved = authService.signup(new SignupRequest("  alice_trim  ", "pw12345"));
+
+        assertThat(saved.getUsername()).isEqualTo("alice_trim");
+    }
+}

--- a/src/test/java/com/example/board/user/SignupRequestTest.java
+++ b/src/test/java/com/example/board/user/SignupRequestTest.java
@@ -1,0 +1,26 @@
+package com.example.board.user;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+import org.junit.jupiter.api.Test;
+
+class SignupRequestTest {
+
+    @Test
+    void 인자_생성자로_필드가_세팅된다() {
+        SignupRequest request = new SignupRequest("alice", "pw12345");
+
+        assertThat(request.getUsername()).isEqualTo("alice");
+        assertThat(request.getPassword()).isEqualTo("pw12345");
+    }
+
+    @Test
+    void 기본_생성자_후_setter로_필드가_갱신된다() {
+        SignupRequest request = new SignupRequest();
+        request.setUsername("bob");
+        request.setPassword("pw99999");
+
+        assertThat(request.getUsername()).isEqualTo("bob");
+        assertThat(request.getPassword()).isEqualTo("pw99999");
+    }
+}


### PR DESCRIPTION
## Summary
커버리지 게이트가 CI를 빨갛게 만드는지 **의도적으로 확인하기 위한 PR**.

현재 main 커버리지(INSTRUCTION 89.9%)에 95% 임계치를 걸면 **반드시 실패**해야 정상.

## 변경 내역

### \`build.gradle.kts\`
\`\`\`kotlin
tasks.jacocoTestCoverageVerification {
    dependsOn(tasks.test)
    violationRules {
        rule {
            limit {
                counter = "INSTRUCTION"
                value = "COVEREDRATIO"
                minimum = "0.95".toBigDecimal()
            }
        }
    }
}
\`\`\`

### \`.github/workflows/ci.yml\`
- \`test\` 잡에 \`Verify coverage threshold (95% INSTRUCTION)\` 스텝 추가 → \`./gradlew jacocoTestCoverageVerification\`
- Codecov 업로드 / JaCoCo HTML 아티팩트를 \`if: always()\` 로 전환 → 검증 실패해도 리포트 보존
- 검증 스텝을 리포트 업로드 뒤에 배치

## 기대 CI 결과
- **test 잡**: FAIL (커버리지 89.9% < 95%)
  - 실패 메시지 예: \`Rule violated for bundle dihisoft-claude-session: instructions covered ratio is 0.89, but expected minimum is 0.95\`
- **build 잡**: PASS (테스트/커버리지 무관)
- Codecov 업로드 및 HTML 아티팩트는 정상 생성 (if: always())

## 로컬 재현
\`\`\`bash
./gradlew jacocoTestCoverageVerification
# > Task :jacocoTestCoverageVerification FAILED
# Rule violated for bundle dihisoft-claude-session: instructions covered ratio is 0.89, but expected minimum is 0.95
\`\`\`

## 이 PR은 머지하지 마세요
게이트 동작 확인용. 실제 사용할 임계치는 베이스라인에 맞춰 80~85%부터 단계적으로 올리는 것을 권장합니다 (별도 PR로).

🤖 Generated with [Claude Code](https://claude.com/claude-code)