### PR TITLE
feat(auth): #13 [KMS] JWT 인프라 + POST /api/auth/login

### DIFF
--- a/.claude/skills/plan-issue/SKILL.md
+++ b/.claude/skills/plan-issue/SKILL.md
@@ -1,0 +1,249 @@
+---
+name: plan-issue
+description: GitHub 이슈 한 건을 받아 저장소 상태·CLAUDE.md 제약에 맞춰 **분석·분할·계획 수립·하위 이슈 생성**까지 자동으로 끌고 간다. "이슈 분석해줘", "이슈 N번 계획 세워줘", "이거 분할하자" 류 요청에서 호출한다. **구현·커밋·PR 은 범위 밖**(`raise-pr` 또는 자유 구현 흐름). 이 스킬은 이슈 본문·README·기존 코드를 읽어 Context 를 정리하고, 10파일/이슈 한도 등 고유 제약에 걸리면 `x.1/x.2` 형태로 하위 이슈를 쪼갠 뒤 플랜 파일을 남긴다.
+---
+
+# plan-issue — 이슈 분석·분할·계획 수립
+
+이 프로젝트(Spring Boot + Gradle + JaCoCo 95% 게이트 + **이슈당 10파일** 규칙)의 고유 제약에 맞게, **GitHub 이슈 한 건**을 받아 실제 착수 가능한 계획 문서와 GitHub 체계를 만든다.
+
+## 전제
+- 이슈 번호를 받았고(예: `#8`), 저장소는 clone 된 상태.
+- `gh` CLI 인증 완료.
+- Plan mode 로 들어온 상태(플랜 파일 경로가 시스템 메시지로 주어짐) 또는 그에 준하는 맥락.
+- CLAUDE.md / README.md 가 저장소에 있음 — 이 스킬은 두 문서를 반드시 읽는다.
+
+아직 이슈 번호가 없다면 먼저 사용자와 이슈부터 합의한다(이 스킬 범위 밖).
+
+## 언제 사용하는가
+- "이슈 #N 해결 계획 세워줘", "어떻게 쪼개지?" 류 요청
+- 범위가 커 보여 10파일 한도 초과가 의심될 때
+- 이슈 본문이 모호해 착수 전 범위/의존성 확정이 필요할 때
+
+사용하지 말 것:
+- 이미 구현이 끝나 PR 올릴 차례 → `raise-pr`
+- 한 줄 오타 수정 같은 자명한 작업 → 바로 구현
+
+## Phase 1 — 이슈 맥락 수집
+
+### 1.1 이슈 본문 + 의존성
+```bash
+gh issue view <num> --json body,number,title,labels,url,state
+```
+**반드시 확인**
+- 범위 / 결과물 목록 (`JwtTokenProvider`, `POST /api/...` 등 구체 명사)
+- `Depends on #X`, `Parent: #Y` 관계
+- `Closes #Z` 언급
+- 라벨 (부모 라벨은 하위 이슈에 **그대로 승계**)
+
+### 1.2 CLAUDE.md + README.md 정독
+- CLAUDE.md: TDD 사이클, 커밋 컨벤션, 10파일/300줄 한도, Edge case 체크리스트
+- README.md: **API 스펙이 자주 박혀있다.** 이번 프로젝트에선 `expiresIn` 단위(초), JWT 알고리즘(HS256) 같은 결정적 정보가 README에 있음. 본문 파싱과 코드가 어긋나면 README 쪽이 우선권.
+
+### 1.3 Explore 서브에이전트로 병렬 탐색
+스코프가 넓으면 **최대 3개 병렬**. 통상 1개로 충분.
+
+**Explore 에게 반드시 시킬 것**
+- 관련 패키지/클래스 트리 (절대 경로)
+- 재사용 가능한 기존 자산 (Repository 메서드, DTO, EntityManager, 테스트 유틸)
+- 빌드 의존성 (해당 기능에 필요한 lib 가 이미 있나)
+- 기존 테스트 패턴 (MockMvc? @Nested? @Tag("playwright")?)
+- git 로그 — 의존 이슈가 실제로 머지됐는지(`git log main --oneline | head -30`)
+- CI 설정 (`.github/workflows/*.yml`) — jacoco 커버리지 문턱 등
+
+Explore 요청문 템플릿:
+```
+Explore /<repo-root>.
+Issue #<N> requires <short goal>. Report:
+1. Existing auth/<area> infrastructure (package tree, key classes with absolute paths)
+2. Reusable assets (repository methods, DTO patterns, config beans)
+3. Build dependencies relevant to <lib>
+4. Testing patterns (framework, @Nested style, Playwright tag usage)
+5. Whether #<dep> work is on main (git log check)
+6. Relevant conventions from CLAUDE.md (file-count rule, test naming, commit style)
+```
+
+## Phase 2 — 제약 체크 및 분할 결정
+
+### 2.1 예상 파일 수 추정
+받은 범위로 **수정/신규 파일을 모두 카운트**한다.
+- 프로덕션 코드, 테스트 코드, 설정 파일 모두 합산
+- Gradle wrapper 자동생성은 제외
+
+**규칙**
+- **≤ 10파일** → 단일 이슈/PR 로 진행
+- **> 10파일** → 하위 이슈로 분할 권고
+
+### 2.2 분할 단위 — "TDD 한 사이클이 독립적으로 성립하는 feature slice"
+흔한 분할 축:
+- **인프라 / API / UI** — 예: JWT 인프라+API(백엔드) vs 로그인 UI(프론트)
+- **엔티티 / 조회 / 변경** — 예: Post 엔티티+Repository vs 목록 조회 vs 작성/수정/삭제
+- **핵심 / 부가** — 핵심 먼저, 부가(페이지네이션·정렬 등) 나중
+
+나쁜 분할 축: "테스트만", "리팩터만" — 독립 feature slice 가 아님.
+
+### 2.3 번호·이름 체계
+- 하위 이슈 번호: 부모 `x.y` → `x.y.1`, `x.y.2` (예: 2.2 → 2.2.1, 2.2.2)
+- 하위 이슈 제목: **담당자 이니셜 prefix + 번호 + 주제** (예: `kms-2.2.1 JWT 인프라 + 로그인 API`)
+  - prefix는 사용자에게 한 번 물어 고정 (AskUserQuestion)
+- 브랜치명: `<prefix>/<번호>-<kebab-주제>` (예: `kms/2.2.1-jwt-login-api`)
+
+## Phase 3 — 사용자 확인 (AskUserQuestion)
+
+탐색·제약 체크에서 확정 못 한 것만 **최소 질문으로 확인**. 흔한 질문 축:
+
+1. **분할 여부** — 파일이 10개 근처면: "단일 PR vs 2개 PR?" (추천은 근거와 함께 제시)
+2. **담당자 prefix / 이니셜** — 이미 이번 세션에서 `kms` 로 고정됐다면 생략, 처음이면 확인
+3. **브랜치명 / 하위 이슈 제목 형식** — 부모 이슈 제목 형식 보여주고 일관성 있게 선택지 제공
+4. **기술 선택** — 예: SPA용 localStorage vs httpOnly 쿠키, 동기/비동기, 롤백 전략
+
+묻지 말 것:
+- 코드에서 읽으면 되는 것 (패키지 구조, 현재 SecurityConfig 내용 등)
+- 이미 이슈 본문에 박혀있는 것
+
+## Phase 4 — Plan 에이전트 (선택)
+
+범위가 크거나 설계 판단이 필요하면 Plan 서브에이전트 1개 사용.
+트리비얼한 단일 파일 작업이면 생략.
+
+Plan 에이전트에 제공:
+- Phase 1 요약 (파일 경로 + 클래스명 포함)
+- 제약 (10파일·300줄·95% 커버리지·TDD 필수)
+- 사용자가 고른 옵션 (Phase 3)
+- 요청: "step-by-step 구현 계획 + 수정 파일 목록 + TDD 커밋 시퀀스 + 검증 방법"
+
+## Phase 5 — 플랜 파일 작성
+
+시스템 메시지가 지정한 경로(예: `~/.claude/plans/<adjective>.md`)에 **한 파일**로 쓴다. 구조:
+
+```markdown
+# Issue #<N> — <제목> 구현 계획
+
+## Context
+대상 이슈: <URL>
+의존성: #<dep> (상태: 머지됨/진행중)
+왜: <해결하려는 문제, 기대 결과>
+프로젝트 제약: 10파일·300줄·95% 커버리지·TDD
+
+## 이슈 분할 전략 (필요 시)
+| 하위 이슈 제목 | 범위 | 브랜치 |
+|---|---|---|
+| <prefix>-<x.y.1> ... | ... | <prefix>/<x.y.1>-... |
+| <prefix>-<x.y.2> ... | ... | <prefix>/<x.y.2>-... |
+
+## 하위 이슈 <x.y.1> — <제목>
+### 추가/수정 파일 (총 N개)
+<신규 / 수정 구분, 각 파일 한 줄 요약, 절대 경로>
+**파일 합계**: N ✅
+
+### TDD 커밋 시퀀스
+1. `test: ... RED`
+2. `feat: ...`
+3. `feat: ...`
+4. `refactor: ...` (선택)
+
+### 검증
+- `./gradlew clean build` (커버리지 포함)
+- 수동: curl / bootRun + manual-test
+
+## 재사용 자산
+- `UserRepository.findByUsername(...)` — <파일 경로>
+- ...
+
+## 위험 / 주의
+- secret 플레이스홀더, CORS, 보호 엔드포인트 부재 등
+
+## 크리티컬 파일 경로 요약
+
+## 선행 액션 (승인 직후)
+1. GitHub 하위 이슈 생성 (부모 본문에 링크 추가, 라벨 승계)
+2. `git checkout -b <branch>` 후 RED 테스트부터 착수
+```
+
+**원칙**
+- 추천안 하나만 기술. 대안 나열 금지.
+- 재사용 자산은 절대 경로로 명시 — 구현 시 바로 `import` 가능하도록.
+- TDD 커밋 시퀀스는 **CLAUDE.md 규칙의 커밋 메시지 컨벤션**(`test:`, `feat:`, `refactor:`)을 그대로 사용.
+
+## Phase 6 — GitHub 반영 (승인 후)
+
+사용자가 ExitPlanMode 로 플랜을 승인한 뒤에만 수행. **plan mode 중엔 쓰기 금지**.
+
+### 6.1 하위 이슈 생성 (분할했을 경우)
+```bash
+gh issue create \
+  --title "<prefix>-<x.y.1> <주제>" \
+  --body "$(cat <<'EOF'
+## 목적
+...
+## 범위
+...
+## TDD 커밋 시퀀스
+...
+## 의존성
+- Depends on #<dep>
+- Parent: #<N>
+## 브랜치
+`<prefix>/<x.y.1>-...`
+EOF
+)"
+```
+
+생성 즉시 부모 이슈의 라벨을 **그대로 복사**:
+```bash
+gh issue edit <new-num> --add-label "<label1>,<label2>,<label3>"
+```
+
+### 6.2 부모 이슈 본문 갱신
+부모 본문 상단에 하위 이슈 체크리스트 섹션 추가:
+```markdown
+## 하위 이슈 (<prefix> 담당자 분할)
+- [ ] #<x.y.1> — <prefix>-<x.y.1> <주제>
+- [ ] #<x.y.2> — <prefix>-<x.y.2> <주제>
+
+> CLAUDE.md 의 10파일/이슈 제약을 지키기 위해 2개로 분할.
+```
+`gh issue edit <parent> --body-file /tmp/parent-body.md`.
+
+### 6.3 브랜치 준비 안내
+플랜 파일에 "선행 액션" 으로 이미 적어둠. 구현은 이 스킬 범위 밖 — 이어서 자유 구현 흐름으로 넘어가거나 사용자가 다음 턴에서 지시.
+
+## Phase 7 — ExitPlanMode
+
+`ExitPlanMode` 호출로 계획 승인 대기. `AskUserQuestion` 으로 "플랜 괜찮아요?" 묻기 금지 — 승인은 ExitPlanMode 전용.
+
+---
+
+## 가이드라인 (박스 요약)
+
+- **3단 우선순위**: 이슈 본문 → README → 코드. 충돌 시 README 가 스펙.
+- **10파일 엄격**: 경계선(9~11)이면 분할 제안. 애매하면 `git diff --name-only` 로 실제 확인.
+- **라벨 승계**: 부모 이슈의 라벨을 하위 이슈에 100% 복사. 누락하면 칸반에서 사라짐.
+- **하위 이슈 번호 체계**: `x.y.N` 유지, 담당자 prefix 포함. 독자적 번호 만들지 말 것.
+- **브랜치명과 이슈 번호 1:1**: `<prefix>/<번호>-<주제>` 포맷.
+- **플랜 파일 = 단일 추천안**: 대안·비교표는 Phase 3 질문에서만. 파일에는 확정안만.
+- **Plan mode 쓰기 제약**: 시스템이 지정한 플랜 파일만 편집 가능. GitHub 쓰기(`gh issue create/edit`)는 **승인 후**.
+- **금지**: 구현·커밋·PR·푸시 (→ `raise-pr` 스킬 범위).
+
+## 다른 스킬과의 관계
+
+- **후행**: `raise-pr` — 이 스킬이 만든 플랜·브랜치·하위 이슈를 받아 PR 라이프사이클 진행.
+- **호출 가능**: `manual-test` — Phase 1에서 기존 UI 동작을 확인하고 싶을 때(드묾).
+- **범위 밖**: `review` / `security-review` — 본 스킬은 코드 리뷰를 하지 않음.
+
+---
+
+## 실행 예시 — 이번 세션 #8 흐름 (JWT + 로그인 API + UI)
+
+```
+Phase 1: gh issue view 8 → 범위 파악(JwtTokenProvider, POST /api/auth/login, 로그인 UI)
+         Explore 1개 에이전트로 코드베이스 탐색 → User/AuthService/SignupController 존재, JJWT 0.12.6 의존성 있음,
+         CLAUDE.md 10파일 제약, application.yml 에 app.jwt.secret 플레이스홀더, README 에 HS256/expiresIn=3600초 스펙
+Phase 2: 예상 파일 12+ → 분할 필요
+Phase 3: AskUserQuestion — 분할여부/UI 토큰 처리/브랜치명 → 2개 분할 + kms/2.2.1-... / JS+localStorage 선택
+         AskUserQuestion 2회차 — 하위 이슈 제목 형식 → "kms-x.y.N 주제"
+Phase 5: plans/linked-pondering-rain.md 작성
+Phase 6: gh issue create ×2 (#13, #14) → 라벨 승계(type:feature, area:auth, priority:high)
+         gh issue edit 8 --body ... (하위 이슈 체크리스트 추가)
+Phase 7: ExitPlanMode → 승인 → 이후 kms/2.2.1 브랜치 착수는 자유 구현 흐름으로
+```

--- a/src/main/java/com/example/board/common/GlobalExceptionHandler.java
+++ b/src/main/java/com/example/board/common/GlobalExceptionHandler.java
@@ -7,6 +7,7 @@ import org.slf4j.LoggerFactory;
 import org.springframework.http.HttpStatus;
 import org.springframework.http.ResponseEntity;
 import org.springframework.security.access.AccessDeniedException;
+import org.springframework.security.core.AuthenticationException;
 import org.springframework.web.bind.MethodArgumentNotValidException;
 import org.springframework.web.bind.annotation.ExceptionHandler;
 import org.springframework.web.bind.annotation.RestControllerAdvice;
@@ -36,6 +37,12 @@ public class GlobalExceptionHandler {
     public ResponseEntity<ErrorResponse> handleAccessDenied(
             AccessDeniedException ex, HttpServletRequest request) {
         return respond(HttpStatus.FORBIDDEN, "접근이 거부되었습니다", request);
+    }
+
+    @ExceptionHandler(AuthenticationException.class)
+    public ResponseEntity<ErrorResponse> handleAuthentication(
+            AuthenticationException ex, HttpServletRequest request) {
+        return respond(HttpStatus.UNAUTHORIZED, ex.getMessage(), request);
     }
 
     @ExceptionHandler(IllegalArgumentException.class)

--- a/src/main/java/com/example/board/config/SecurityConfig.java
+++ b/src/main/java/com/example/board/config/SecurityConfig.java
@@ -1,5 +1,6 @@
 package com.example.board.config;
 
+import com.example.board.security.JwtAuthenticationFilter;
 import org.springframework.context.annotation.Bean;
 import org.springframework.context.annotation.Configuration;
 import org.springframework.security.config.annotation.web.builders.HttpSecurity;
@@ -8,6 +9,7 @@ import org.springframework.security.config.http.SessionCreationPolicy;
 import org.springframework.security.crypto.bcrypt.BCryptPasswordEncoder;
 import org.springframework.security.crypto.password.PasswordEncoder;
 import org.springframework.security.web.SecurityFilterChain;
+import org.springframework.security.web.authentication.UsernamePasswordAuthenticationFilter;
 import org.springframework.security.web.util.matcher.AntPathRequestMatcher;
 
 @Configuration
@@ -15,12 +17,15 @@ public class SecurityConfig {
 
     private final RestAuthenticationEntryPoint authenticationEntryPoint;
     private final RestAccessDeniedHandler accessDeniedHandler;
+    private final JwtAuthenticationFilter jwtAuthenticationFilter;
 
     public SecurityConfig(
             RestAuthenticationEntryPoint authenticationEntryPoint,
-            RestAccessDeniedHandler accessDeniedHandler) {
+            RestAccessDeniedHandler accessDeniedHandler,
+            JwtAuthenticationFilter jwtAuthenticationFilter) {
         this.authenticationEntryPoint = authenticationEntryPoint;
         this.accessDeniedHandler = accessDeniedHandler;
+        this.jwtAuthenticationFilter = jwtAuthenticationFilter;
     }
 
     @Bean
@@ -41,6 +46,7 @@ public class SecurityConfig {
                         .requestMatchers(AntPathRequestMatcher.antMatcher("/css/**")).permitAll()
                         .requestMatchers(AntPathRequestMatcher.antMatcher("/webjars/**")).permitAll()
                         .anyRequest().authenticated())
+                .addFilterBefore(jwtAuthenticationFilter, UsernamePasswordAuthenticationFilter.class)
                 .exceptionHandling(ex -> ex
                         .authenticationEntryPoint(authenticationEntryPoint)
                         .accessDeniedHandler(accessDeniedHandler));

--- a/src/main/java/com/example/board/security/JwtAuthenticationFilter.java
+++ b/src/main/java/com/example/board/security/JwtAuthenticationFilter.java
@@ -1,0 +1,50 @@
+package com.example.board.security;
+
+import jakarta.servlet.FilterChain;
+import jakarta.servlet.ServletException;
+import jakarta.servlet.http.HttpServletRequest;
+import jakarta.servlet.http.HttpServletResponse;
+import java.io.IOException;
+import java.util.List;
+import org.springframework.http.HttpHeaders;
+import org.springframework.security.authentication.UsernamePasswordAuthenticationToken;
+import org.springframework.security.core.context.SecurityContextHolder;
+import org.springframework.security.web.authentication.WebAuthenticationDetailsSource;
+import org.springframework.stereotype.Component;
+import org.springframework.web.filter.OncePerRequestFilter;
+
+@Component
+public class JwtAuthenticationFilter extends OncePerRequestFilter {
+
+    private static final String BEARER_PREFIX = "Bearer ";
+
+    private final JwtTokenProvider tokenProvider;
+
+    public JwtAuthenticationFilter(JwtTokenProvider tokenProvider) {
+        this.tokenProvider = tokenProvider;
+    }
+
+    @Override
+    protected void doFilterInternal(
+            HttpServletRequest request,
+            HttpServletResponse response,
+            FilterChain filterChain) throws ServletException, IOException {
+        String token = resolveToken(request);
+        if (token != null && tokenProvider.validate(token)) {
+            String username = tokenProvider.extractUsername(token);
+            UsernamePasswordAuthenticationToken authentication =
+                    new UsernamePasswordAuthenticationToken(username, null, List.of());
+            authentication.setDetails(new WebAuthenticationDetailsSource().buildDetails(request));
+            SecurityContextHolder.getContext().setAuthentication(authentication);
+        }
+        filterChain.doFilter(request, response);
+    }
+
+    private String resolveToken(HttpServletRequest request) {
+        String header = request.getHeader(HttpHeaders.AUTHORIZATION);
+        if (header != null && header.startsWith(BEARER_PREFIX)) {
+            return header.substring(BEARER_PREFIX.length()).trim();
+        }
+        return null;
+    }
+}

--- a/src/main/java/com/example/board/security/JwtTokenProvider.java
+++ b/src/main/java/com/example/board/security/JwtTokenProvider.java
@@ -1,9 +1,10 @@
 package com.example.board.security;
 
 import io.jsonwebtoken.Claims;
-import io.jsonwebtoken.JwtException;
 import io.jsonwebtoken.Jwts;
+import io.jsonwebtoken.JwtException;
 import io.jsonwebtoken.security.Keys;
+import io.jsonwebtoken.security.MacAlgorithm;
 import java.nio.charset.StandardCharsets;
 import java.util.Date;
 import javax.crypto.SecretKey;
@@ -12,6 +13,8 @@ import org.springframework.stereotype.Component;
 
 @Component
 public class JwtTokenProvider {
+
+    private static final MacAlgorithm SIGNATURE_ALGORITHM = Jwts.SIG.HS256;
 
     private final SecretKey key;
     private final long expirationMs;
@@ -30,7 +33,7 @@ public class JwtTokenProvider {
                 .subject(username)
                 .issuedAt(now)
                 .expiration(expiry)
-                .signWith(key)
+                .signWith(key, SIGNATURE_ALGORITHM)
                 .compact();
     }
 

--- a/src/main/java/com/example/board/security/JwtTokenProvider.java
+++ b/src/main/java/com/example/board/security/JwtTokenProvider.java
@@ -1,0 +1,64 @@
+package com.example.board.security;
+
+import io.jsonwebtoken.Claims;
+import io.jsonwebtoken.JwtException;
+import io.jsonwebtoken.Jwts;
+import io.jsonwebtoken.security.Keys;
+import java.nio.charset.StandardCharsets;
+import java.util.Date;
+import javax.crypto.SecretKey;
+import org.springframework.beans.factory.annotation.Value;
+import org.springframework.stereotype.Component;
+
+@Component
+public class JwtTokenProvider {
+
+    private final SecretKey key;
+    private final long expirationMs;
+
+    public JwtTokenProvider(
+            @Value("${app.jwt.secret}") String secret,
+            @Value("${app.jwt.expiration-ms}") long expirationMs) {
+        this.key = Keys.hmacShaKeyFor(secret.getBytes(StandardCharsets.UTF_8));
+        this.expirationMs = expirationMs;
+    }
+
+    public String generate(String username) {
+        Date now = new Date();
+        Date expiry = new Date(now.getTime() + expirationMs);
+        return Jwts.builder()
+                .subject(username)
+                .issuedAt(now)
+                .expiration(expiry)
+                .signWith(key)
+                .compact();
+    }
+
+    public boolean validate(String token) {
+        if (token == null || token.isBlank()) {
+            return false;
+        }
+        try {
+            parse(token);
+            return true;
+        } catch (JwtException | IllegalArgumentException ex) {
+            return false;
+        }
+    }
+
+    public String extractUsername(String token) {
+        return parse(token).getSubject();
+    }
+
+    public long getExpirationMs() {
+        return expirationMs;
+    }
+
+    private Claims parse(String token) {
+        return Jwts.parser()
+                .verifyWith(key)
+                .build()
+                .parseSignedClaims(token)
+                .getPayload();
+    }
+}

--- a/src/main/java/com/example/board/user/AuthController.java
+++ b/src/main/java/com/example/board/user/AuthController.java
@@ -29,6 +29,12 @@ public class AuthController {
                 .body(new SignupResponse(user.getId(), user.getUsername()));
     }
 
+    @PostMapping("/api/auth/login")
+    @ResponseBody
+    public ResponseEntity<LoginResponse> loginApi(@Valid @RequestBody LoginRequest request) {
+        return ResponseEntity.ok(authService.login(request));
+    }
+
     @GetMapping("/signup")
     public String signupForm(Model model) {
         if (!model.containsAttribute("signupRequest")) {

--- a/src/main/java/com/example/board/user/AuthService.java
+++ b/src/main/java/com/example/board/user/AuthService.java
@@ -1,5 +1,7 @@
 package com.example.board.user;
 
+import com.example.board.security.JwtTokenProvider;
+import org.springframework.security.authentication.BadCredentialsException;
 import org.springframework.security.crypto.password.PasswordEncoder;
 import org.springframework.stereotype.Service;
 import org.springframework.transaction.annotation.Transactional;
@@ -7,12 +9,19 @@ import org.springframework.transaction.annotation.Transactional;
 @Service
 public class AuthService {
 
+    private static final String INVALID_CREDENTIALS = "아이디 또는 비밀번호가 올바르지 않습니다";
+
     private final UserRepository userRepository;
     private final PasswordEncoder passwordEncoder;
+    private final JwtTokenProvider jwtTokenProvider;
 
-    public AuthService(UserRepository userRepository, PasswordEncoder passwordEncoder) {
+    public AuthService(
+            UserRepository userRepository,
+            PasswordEncoder passwordEncoder,
+            JwtTokenProvider jwtTokenProvider) {
         this.userRepository = userRepository;
         this.passwordEncoder = passwordEncoder;
+        this.jwtTokenProvider = jwtTokenProvider;
     }
 
     @Transactional
@@ -26,5 +35,16 @@ public class AuthService {
         }
         String hashed = passwordEncoder.encode(request.getPassword());
         return userRepository.save(new User(username, hashed));
+    }
+
+    @Transactional(readOnly = true)
+    public LoginResponse login(LoginRequest request) {
+        User user = userRepository.findByUsername(request.getUsername())
+                .orElseThrow(() -> new BadCredentialsException(INVALID_CREDENTIALS));
+        if (!passwordEncoder.matches(request.getPassword(), user.getPassword())) {
+            throw new BadCredentialsException(INVALID_CREDENTIALS);
+        }
+        String token = jwtTokenProvider.generate(user.getUsername());
+        return LoginResponse.bearer(token, jwtTokenProvider.getExpirationMs());
     }
 }

--- a/src/main/java/com/example/board/user/LoginRequest.java
+++ b/src/main/java/com/example/board/user/LoginRequest.java
@@ -1,0 +1,36 @@
+package com.example.board.user;
+
+import jakarta.validation.constraints.NotBlank;
+
+public class LoginRequest {
+
+    @NotBlank(message = "username은 필수입니다")
+    private String username;
+
+    @NotBlank(message = "password는 필수입니다")
+    private String password;
+
+    public LoginRequest() {
+    }
+
+    public LoginRequest(String username, String password) {
+        this.username = username;
+        this.password = password;
+    }
+
+    public String getUsername() {
+        return username;
+    }
+
+    public void setUsername(String username) {
+        this.username = username;
+    }
+
+    public String getPassword() {
+        return password;
+    }
+
+    public void setPassword(String password) {
+        this.password = password;
+    }
+}

--- a/src/main/java/com/example/board/user/LoginResponse.java
+++ b/src/main/java/com/example/board/user/LoginResponse.java
@@ -1,0 +1,8 @@
+package com.example.board.user;
+
+public record LoginResponse(String accessToken, String tokenType, long expiresIn) {
+
+    public static LoginResponse bearer(String accessToken, long expirationMs) {
+        return new LoginResponse(accessToken, "Bearer", expirationMs / 1000L);
+    }
+}

--- a/src/test/java/com/example/board/security/JwtTokenProviderTest.java
+++ b/src/test/java/com/example/board/security/JwtTokenProviderTest.java
@@ -1,0 +1,68 @@
+package com.example.board.security;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+import org.junit.jupiter.api.Test;
+
+class JwtTokenProviderTest {
+
+    private static final String SECRET_A =
+            "test-secret-AAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAA";
+    private static final String SECRET_B =
+            "test-secret-BBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBB";
+
+    @Test
+    void generate_한_토큰을_validate로_검증하고_username을_추출할_수_있다() {
+        JwtTokenProvider provider = new JwtTokenProvider(SECRET_A, 60_000L);
+
+        String token = provider.generate("alice");
+
+        assertThat(token).isNotBlank();
+        assertThat(provider.validate(token)).isTrue();
+        assertThat(provider.extractUsername(token)).isEqualTo("alice");
+    }
+
+    @Test
+    void 만료된_토큰은_validate가_false를_반환한다() throws InterruptedException {
+        JwtTokenProvider provider = new JwtTokenProvider(SECRET_A, 1L);
+        String token = provider.generate("alice");
+
+        Thread.sleep(50L);
+
+        assertThat(provider.validate(token)).isFalse();
+    }
+
+    @Test
+    void 서명이_다른_secret으로_만든_토큰은_validate가_false를_반환한다() {
+        JwtTokenProvider signer = new JwtTokenProvider(SECRET_A, 60_000L);
+        JwtTokenProvider verifier = new JwtTokenProvider(SECRET_B, 60_000L);
+
+        String token = signer.generate("alice");
+
+        assertThat(verifier.validate(token)).isFalse();
+    }
+
+    @Test
+    void malformed_토큰은_validate가_false를_반환한다() {
+        JwtTokenProvider provider = new JwtTokenProvider(SECRET_A, 60_000L);
+
+        assertThat(provider.validate("not-a-jwt")).isFalse();
+        assertThat(provider.validate("aaa.bbb.ccc")).isFalse();
+    }
+
+    @Test
+    void null_또는_빈_토큰은_validate가_false를_반환한다() {
+        JwtTokenProvider provider = new JwtTokenProvider(SECRET_A, 60_000L);
+
+        assertThat(provider.validate(null)).isFalse();
+        assertThat(provider.validate("")).isFalse();
+        assertThat(provider.validate("   ")).isFalse();
+    }
+
+    @Test
+    void getExpirationMs는_생성자에_주입된_값을_반환한다() {
+        JwtTokenProvider provider = new JwtTokenProvider(SECRET_A, 3_600_000L);
+
+        assertThat(provider.getExpirationMs()).isEqualTo(3_600_000L);
+    }
+}

--- a/src/test/java/com/example/board/user/LoginControllerTest.java
+++ b/src/test/java/com/example/board/user/LoginControllerTest.java
@@ -1,0 +1,183 @@
+package com.example.board.user;
+
+import static org.hamcrest.Matchers.containsString;
+import static org.hamcrest.Matchers.startsWith;
+import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.get;
+import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.post;
+import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.jsonPath;
+import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.status;
+
+import com.example.board.security.JwtTokenProvider;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Nested;
+import org.junit.jupiter.api.Test;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.boot.test.autoconfigure.web.servlet.AutoConfigureMockMvc;
+import org.springframework.boot.test.context.SpringBootTest;
+import org.springframework.http.MediaType;
+import org.springframework.test.context.ActiveProfiles;
+import org.springframework.test.web.servlet.MockMvc;
+
+@SpringBootTest
+@AutoConfigureMockMvc
+@ActiveProfiles("test")
+class LoginControllerTest {
+
+    private static final String USERNAME = "loginuser";
+    private static final String PASSWORD = "pw12345";
+    private static final String ALT_SECRET =
+            "alt-secret-XXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXX";
+
+    @Autowired
+    MockMvc mockMvc;
+
+    @Autowired
+    UserRepository userRepository;
+
+    @Autowired
+    AuthService authService;
+
+    @Autowired
+    JwtTokenProvider jwtTokenProvider;
+
+    @BeforeEach
+    void cleanAndSeed() {
+        userRepository.deleteAll();
+        authService.signup(new SignupRequest(USERNAME, PASSWORD));
+    }
+
+    @Nested
+    class RestApi {
+
+        @Test
+        void 로그인_성공시_200과_accessToken_tokenType_expiresIn을_반환한다() throws Exception {
+            mockMvc.perform(post("/api/auth/login")
+                            .contentType(MediaType.APPLICATION_JSON)
+                            .content("{\"username\":\"" + USERNAME + "\",\"password\":\"" + PASSWORD + "\"}"))
+                    .andExpect(status().isOk())
+                    .andExpect(jsonPath("$.accessToken").isString())
+                    .andExpect(jsonPath("$.accessToken").value(startsWith("ey")))
+                    .andExpect(jsonPath("$.tokenType").value("Bearer"))
+                    .andExpect(jsonPath("$.expiresIn").isNumber());
+        }
+
+        @Test
+        void 존재하지_않는_username이면_401과_ErrorResponse를_반환한다() throws Exception {
+            mockMvc.perform(post("/api/auth/login")
+                            .contentType(MediaType.APPLICATION_JSON)
+                            .content("{\"username\":\"ghost\",\"password\":\"" + PASSWORD + "\"}"))
+                    .andExpect(status().isUnauthorized())
+                    .andExpect(jsonPath("$.status").value(401))
+                    .andExpect(jsonPath("$.error").value("Unauthorized"))
+                    .andExpect(jsonPath("$.message").exists());
+        }
+
+        @Test
+        void 잘못된_password면_401을_반환한다() throws Exception {
+            mockMvc.perform(post("/api/auth/login")
+                            .contentType(MediaType.APPLICATION_JSON)
+                            .content("{\"username\":\"" + USERNAME + "\",\"password\":\"wrong-pw\"}"))
+                    .andExpect(status().isUnauthorized())
+                    .andExpect(jsonPath("$.status").value(401));
+        }
+
+        @Test
+        void username이_null이면_400을_반환한다() throws Exception {
+            mockMvc.perform(post("/api/auth/login")
+                            .contentType(MediaType.APPLICATION_JSON)
+                            .content("{\"password\":\"" + PASSWORD + "\"}"))
+                    .andExpect(status().isBadRequest())
+                    .andExpect(jsonPath("$.message").value(containsString("username")));
+        }
+
+        @Test
+        void password가_null이면_400을_반환한다() throws Exception {
+            mockMvc.perform(post("/api/auth/login")
+                            .contentType(MediaType.APPLICATION_JSON)
+                            .content("{\"username\":\"" + USERNAME + "\"}"))
+                    .andExpect(status().isBadRequest())
+                    .andExpect(jsonPath("$.message").value(containsString("password")));
+        }
+
+        @Test
+        void username이_빈문자열이면_400을_반환한다() throws Exception {
+            mockMvc.perform(post("/api/auth/login")
+                            .contentType(MediaType.APPLICATION_JSON)
+                            .content("{\"username\":\"\",\"password\":\"" + PASSWORD + "\"}"))
+                    .andExpect(status().isBadRequest());
+        }
+
+        @Test
+        void password가_빈문자열이면_400을_반환한다() throws Exception {
+            mockMvc.perform(post("/api/auth/login")
+                            .contentType(MediaType.APPLICATION_JSON)
+                            .content("{\"username\":\"" + USERNAME + "\",\"password\":\"\"}"))
+                    .andExpect(status().isBadRequest());
+        }
+
+        @Test
+        void password는_응답에_포함되지_않는다() throws Exception {
+            mockMvc.perform(post("/api/auth/login")
+                            .contentType(MediaType.APPLICATION_JSON)
+                            .content("{\"username\":\"" + USERNAME + "\",\"password\":\"" + PASSWORD + "\"}"))
+                    .andExpect(jsonPath("$.password").doesNotExist());
+        }
+    }
+
+    @Nested
+    class JwtFilter {
+
+        @Test
+        void 유효한_Bearer_토큰이면_보호_엔드포인트에_접근할_수_있다() throws Exception {
+            String token = jwtTokenProvider.generate(USERNAME);
+
+            mockMvc.perform(get("/__probe/secured")
+                            .header("Authorization", "Bearer " + token))
+                    .andExpect(status().isOk());
+        }
+
+        @Test
+        void Authorization_헤더가_없으면_401이다() throws Exception {
+            mockMvc.perform(get("/__probe/secured"))
+                    .andExpect(status().isUnauthorized());
+        }
+
+        @Test
+        void Bearer_prefix가_아니면_401이다() throws Exception {
+            String token = jwtTokenProvider.generate(USERNAME);
+
+            mockMvc.perform(get("/__probe/secured")
+                            .header("Authorization", "Token " + token))
+                    .andExpect(status().isUnauthorized());
+        }
+
+        @Test
+        void 서명이_틀린_토큰이면_401이다() throws Exception {
+            String tampered = new JwtTokenProvider(ALT_SECRET, 60_000L).generate(USERNAME);
+
+            mockMvc.perform(get("/__probe/secured")
+                            .header("Authorization", "Bearer " + tampered))
+                    .andExpect(status().isUnauthorized());
+        }
+
+        @Test
+        void 만료된_토큰이면_401이다() throws Exception {
+            String expired = new JwtTokenProvider(
+                    "test-secret-test-secret-test-secret-test-secret-test-secret-64!",
+                    1L)
+                    .generate(USERNAME);
+            Thread.sleep(50L);
+
+            mockMvc.perform(get("/__probe/secured")
+                            .header("Authorization", "Bearer " + expired))
+                    .andExpect(status().isUnauthorized());
+        }
+
+        @Test
+        void malformed_토큰이면_401이다() throws Exception {
+            mockMvc.perform(get("/__probe/secured")
+                            .header("Authorization", "Bearer not-a-valid-jwt"))
+                    .andExpect(status().isUnauthorized());
+        }
+    }
+}


### PR DESCRIPTION
Closes #13

## Summary
- JJWT 0.12.6 기반 `JwtTokenProvider` 로 HS256 서명된 JWT 발급·검증·username 추출.
- `JwtAuthenticationFilter` 를 `UsernamePasswordAuthenticationFilter` 앞에 등록해 `Authorization: Bearer <token>` 으로 SecurityContext 인증 주입.
- `POST /api/auth/login` 엔드포인트와 `AuthService.login` 로 BCrypt 검증 후 JWT 발급, 실패 시 401.
- **추가(범위 확장)**: 이번 세션 워크플로우를 정형화한 `plan-issue` 스킬 문서 동봉.

## TDD 증적
커밋 쌍 (RED → GREEN 3회 + REFACTOR + chore):
- `test: JWT 인프라 + 로그인 API RED 테스트 추가` — JwtTokenProviderTest(6), LoginControllerTest(RestApi 8 + JwtFilter 6)
- `feat: JwtTokenProvider 구현 - JJWT 기반 HS256 서명`
- `feat: JwtAuthenticationFilter 구현 및 SecurityConfig 체인 등록`
- `feat: POST /api/auth/login - 로그인 API + JWT 발급`
- `refactor: JwtTokenProvider HS256 명시 - README 스펙 정합`
- `chore: plan-issue 스킬 추가 - 이슈 분석·분할·계획 수립 워크플로우`

RED에서 선제 설계한 edge case:
- **인증/권한**: 토큰 없음, Bearer prefix 아님, 서명 위변조, 만료, malformed
- **입력 검증**: username/password blank, null
- **리소스 상태**: 존재하지 않는 username, 잘못된 password
- **응답 안전성**: 로그인 응답에 password 미포함

## Test plan
- [x] `./gradlew clean build` 로컬 초록불 — 54 tests PASS
- [x] `./gradlew jacocoTestCoverageVerification` — INSTRUCTION 97.70% (≥95%)
- [x] CI 초록불 (이전 run) — `Test + Coverage`: SUCCESS, `Build (no tests)`: SUCCESS (run 24763410298)
- [x] CI 재검증 (스킬 문서 추가 후) — `Test + Coverage`: SUCCESS, `Build (no tests)`: SUCCESS (run 24764210713)
- [x] 수동 검증 (curl 8종): 가입 201 · 로그인 200 + accessToken/Bearer/expiresIn=3600 · 보호경로 토큰없음 401 / 유효토큰 404(인증 통과) / 변조서명 401 · 잘못된 비번/존재하지 않는 user 401 · blank 400

## 파일 변경 요약 (11개, ≤10 규칙 1파일 초과 — 사전 합의)
| # | 파일 | 구분 | 비고 |
|---|---|---|---|
| 1 | `src/main/java/.../common/GlobalExceptionHandler.java` | 수정 | AuthenticationException → 401 핸들러 추가 |
| 2 | `src/main/java/.../config/SecurityConfig.java` | 수정 | JwtAuthenticationFilter 체인 등록 |
| 3 | `src/main/java/.../security/JwtTokenProvider.java` | 신규 | JJWT 토큰 생성/검증/추출 (HS256 명시) |
| 4 | `src/main/java/.../security/JwtAuthenticationFilter.java` | 신규 | Bearer 헤더 파싱 필터 |
| 5 | `src/main/java/.../user/LoginRequest.java` | 신규 | @NotBlank 검증 DTO |
| 6 | `src/main/java/.../user/LoginResponse.java` | 신규 | accessToken/tokenType/expiresIn(초) |
| 7 | `src/main/java/.../user/AuthService.java` | 수정 | login(LoginRequest) 메서드 추가 |
| 8 | `src/main/java/.../user/AuthController.java` | 수정 | POST /api/auth/login 추가 |
| 9 | `src/test/java/.../security/JwtTokenProviderTest.java` | 신규 | 6 tests |
| 10 | `src/test/java/.../user/LoginControllerTest.java` | 신규 | 14 tests (RestApi 8, JwtFilter 6) |
| 11 | `.claude/skills/plan-issue/SKILL.md` | 신규 | 이슈 분석·분할·계획 스킬 문서 — 아래 "주의" 참고 |

## 주의
- `app.jwt.secret` 은 application.yml 의 플레이스홀더 그대로. 운영 배포 시 환경변수 주입 필요(범위 밖).
- 로그인 UI 는 **#14 (kms-2.2.2)** 에서 별 브랜치로 진행. 이 PR은 REST/인프라만.
- **≤10 파일 규칙 1파일 초과 (11파일) — 사전 합의된 예외**:
  - 11번째 파일 `.claude/skills/plan-issue/SKILL.md` 는 프로덕션/테스트/설정 코드가 아닌 **AI 협업 메타 파일(스킬 문서)**.
  - 규칙의 취지(리뷰 부담·범위 혼탁)에 실질 영향 없음 — 코드 diff 는 여전히 10파일.
  - 선례: PR #6 (foundation 예외), `chore: raise-pr 스킬 추가` 커밋 와 동일 성격.
  - 별 PR 로 분리할 수도 있었으나 사용자 지시에 따라 본 PR 에 합류.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
