### PR TITLE
feat(auth): #8 JWT 인프라 + 로그인 API + 로그인 UI (2.2)

### DIFF
--- a/src/main/java/com/example/board/config/SecurityConfig.java
+++ b/src/main/java/com/example/board/config/SecurityConfig.java
@@ -1,13 +1,17 @@
 package com.example.board.config;
 
+import com.example.board.security.JwtAuthenticationFilter;
 import org.springframework.context.annotation.Bean;
 import org.springframework.context.annotation.Configuration;
+import org.springframework.security.authentication.AuthenticationManager;
+import org.springframework.security.config.annotation.authentication.configuration.AuthenticationConfiguration;
 import org.springframework.security.config.annotation.web.builders.HttpSecurity;
 import org.springframework.security.config.annotation.web.configurers.HeadersConfigurer;
 import org.springframework.security.config.http.SessionCreationPolicy;
 import org.springframework.security.crypto.bcrypt.BCryptPasswordEncoder;
 import org.springframework.security.crypto.password.PasswordEncoder;
 import org.springframework.security.web.SecurityFilterChain;
+import org.springframework.security.web.authentication.UsernamePasswordAuthenticationFilter;
 import org.springframework.security.web.util.matcher.AntPathRequestMatcher;
 
 @Configuration
@@ -15,17 +19,25 @@ public class SecurityConfig {
 
     private final RestAuthenticationEntryPoint authenticationEntryPoint;
     private final RestAccessDeniedHandler accessDeniedHandler;
+    private final JwtAuthenticationFilter jwtAuthenticationFilter;
 
     public SecurityConfig(
             RestAuthenticationEntryPoint authenticationEntryPoint,
-            RestAccessDeniedHandler accessDeniedHandler) {
+            RestAccessDeniedHandler accessDeniedHandler,
+            JwtAuthenticationFilter jwtAuthenticationFilter) {
         this.authenticationEntryPoint = authenticationEntryPoint;
         this.accessDeniedHandler = accessDeniedHandler;
+        this.jwtAuthenticationFilter = jwtAuthenticationFilter;
     }
 
     @Bean
     public PasswordEncoder passwordEncoder() {
         return new BCryptPasswordEncoder();
+    }
+
+    @Bean
+    public AuthenticationManager authenticationManager(AuthenticationConfiguration configuration) throws Exception {
+        return configuration.getAuthenticationManager();
     }
 
     @Bean
@@ -38,12 +50,14 @@ public class SecurityConfig {
                         .requestMatchers(AntPathRequestMatcher.antMatcher("/h2-console/**")).permitAll()
                         .requestMatchers(AntPathRequestMatcher.antMatcher("/api/auth/**")).permitAll()
                         .requestMatchers(AntPathRequestMatcher.antMatcher("/signup")).permitAll()
+                        .requestMatchers(AntPathRequestMatcher.antMatcher("/login")).permitAll()
                         .requestMatchers(AntPathRequestMatcher.antMatcher("/css/**")).permitAll()
                         .requestMatchers(AntPathRequestMatcher.antMatcher("/webjars/**")).permitAll()
                         .anyRequest().authenticated())
                 .exceptionHandling(ex -> ex
                         .authenticationEntryPoint(authenticationEntryPoint)
-                        .accessDeniedHandler(accessDeniedHandler));
+                        .accessDeniedHandler(accessDeniedHandler))
+                .addFilterBefore(jwtAuthenticationFilter, UsernamePasswordAuthenticationFilter.class);
         return http.build();
     }
 }

--- a/src/main/java/com/example/board/security/CustomUserDetailsService.java
+++ b/src/main/java/com/example/board/security/CustomUserDetailsService.java
@@ -1,0 +1,30 @@
+package com.example.board.security;
+
+import com.example.board.user.User;
+import com.example.board.user.UserRepository;
+import java.util.Collections;
+import org.springframework.security.core.userdetails.UserDetails;
+import org.springframework.security.core.userdetails.UserDetailsService;
+import org.springframework.security.core.userdetails.UsernameNotFoundException;
+import org.springframework.stereotype.Service;
+
+@Service
+public class CustomUserDetailsService implements UserDetailsService {
+
+    private final UserRepository userRepository;
+
+    public CustomUserDetailsService(UserRepository userRepository) {
+        this.userRepository = userRepository;
+    }
+
+    @Override
+    public UserDetails loadUserByUsername(String username) throws UsernameNotFoundException {
+        User user = userRepository.findByUsername(username)
+                .orElseThrow(() -> new UsernameNotFoundException("사용자를 찾을 수 없습니다: " + username));
+        return org.springframework.security.core.userdetails.User.builder()
+                .username(user.getUsername())
+                .password(user.getPassword())
+                .authorities(Collections.emptyList())
+                .build();
+    }
+}

--- a/src/main/java/com/example/board/security/JwtAuthenticationFilter.java
+++ b/src/main/java/com/example/board/security/JwtAuthenticationFilter.java
@@ -1,0 +1,55 @@
+package com.example.board.security;
+
+import jakarta.servlet.FilterChain;
+import jakarta.servlet.ServletException;
+import jakarta.servlet.http.HttpServletRequest;
+import jakarta.servlet.http.HttpServletResponse;
+import java.io.IOException;
+import java.util.Optional;
+import org.springframework.security.authentication.UsernamePasswordAuthenticationToken;
+import org.springframework.security.core.context.SecurityContextHolder;
+import org.springframework.security.core.userdetails.UserDetails;
+import org.springframework.security.core.userdetails.UserDetailsService;
+import org.springframework.security.core.userdetails.UsernameNotFoundException;
+import org.springframework.security.web.authentication.WebAuthenticationDetailsSource;
+import org.springframework.stereotype.Component;
+import org.springframework.web.filter.OncePerRequestFilter;
+
+@Component
+public class JwtAuthenticationFilter extends OncePerRequestFilter {
+
+    private static final String HEADER = "Authorization";
+    private static final String BEARER_PREFIX = "Bearer ";
+
+    private final JwtTokenProvider jwtTokenProvider;
+    private final UserDetailsService userDetailsService;
+
+    public JwtAuthenticationFilter(JwtTokenProvider jwtTokenProvider, UserDetailsService userDetailsService) {
+        this.jwtTokenProvider = jwtTokenProvider;
+        this.userDetailsService = userDetailsService;
+    }
+
+    @Override
+    protected void doFilterInternal(
+            HttpServletRequest request, HttpServletResponse response, FilterChain chain)
+            throws ServletException, IOException {
+        String header = request.getHeader(HEADER);
+        if (header != null && header.startsWith(BEARER_PREFIX)) {
+            String token = header.substring(BEARER_PREFIX.length());
+            Optional<String> username = jwtTokenProvider.resolveUsername(token);
+            if (username.isPresent() && SecurityContextHolder.getContext().getAuthentication() == null) {
+                try {
+                    UserDetails userDetails = userDetailsService.loadUserByUsername(username.get());
+                    UsernamePasswordAuthenticationToken authentication =
+                            new UsernamePasswordAuthenticationToken(
+                                    userDetails, null, userDetails.getAuthorities());
+                    authentication.setDetails(new WebAuthenticationDetailsSource().buildDetails(request));
+                    SecurityContextHolder.getContext().setAuthentication(authentication);
+                } catch (UsernameNotFoundException ignored) {
+                    // 토큰은 유효하나 사용자 미존재: 컨텍스트 미주입 → 이후 EntryPoint가 401 처리
+                }
+            }
+        }
+        chain.doFilter(request, response);
+    }
+}

--- a/src/main/java/com/example/board/security/JwtTokenProvider.java
+++ b/src/main/java/com/example/board/security/JwtTokenProvider.java
@@ -1,0 +1,16 @@
+package com.example.board.security;
+
+import java.util.Optional;
+import org.springframework.stereotype.Component;
+
+@Component
+public class JwtTokenProvider {
+
+    public String generateToken(String username) {
+        throw new UnsupportedOperationException("JwtTokenProvider.generateToken 미구현 (RED)");
+    }
+
+    public Optional<String> resolveUsername(String token) {
+        throw new UnsupportedOperationException("JwtTokenProvider.resolveUsername 미구현 (RED)");
+    }
+}

--- a/src/main/java/com/example/board/security/JwtTokenProvider.java
+++ b/src/main/java/com/example/board/security/JwtTokenProvider.java
@@ -1,16 +1,54 @@
 package com.example.board.security;
 
+import io.jsonwebtoken.Claims;
+import io.jsonwebtoken.JwtException;
+import io.jsonwebtoken.Jwts;
+import io.jsonwebtoken.security.Keys;
+import java.nio.charset.StandardCharsets;
+import java.util.Date;
 import java.util.Optional;
+import javax.crypto.SecretKey;
+import org.springframework.beans.factory.annotation.Value;
 import org.springframework.stereotype.Component;
 
 @Component
 public class JwtTokenProvider {
 
+    private final SecretKey key;
+    private final long expirationMs;
+
+    public JwtTokenProvider(
+            @Value("${app.jwt.secret}") String secret,
+            @Value("${app.jwt.expiration-ms}") long expirationMs) {
+        this.key = Keys.hmacShaKeyFor(secret.getBytes(StandardCharsets.UTF_8));
+        this.expirationMs = expirationMs;
+    }
+
     public String generateToken(String username) {
-        throw new UnsupportedOperationException("JwtTokenProvider.generateToken 미구현 (RED)");
+        Date now = new Date();
+        Date expiry = new Date(now.getTime() + expirationMs);
+        return Jwts.builder()
+                .subject(username)
+                .issuedAt(now)
+                .expiration(expiry)
+                .signWith(key, Jwts.SIG.HS256)
+                .compact();
     }
 
     public Optional<String> resolveUsername(String token) {
-        throw new UnsupportedOperationException("JwtTokenProvider.resolveUsername 미구현 (RED)");
+        try {
+            Claims claims = Jwts.parser()
+                    .verifyWith(key)
+                    .build()
+                    .parseSignedClaims(token)
+                    .getPayload();
+            return Optional.ofNullable(claims.getSubject());
+        } catch (JwtException | IllegalArgumentException ex) {
+            return Optional.empty();
+        }
+    }
+
+    public long getExpirationMs() {
+        return expirationMs;
     }
 }

--- a/src/main/java/com/example/board/user/AuthController.java
+++ b/src/main/java/com/example/board/user/AuthController.java
@@ -1,8 +1,13 @@
 package com.example.board.user;
 
+import com.example.board.common.ErrorResponse;
+import jakarta.servlet.http.Cookie;
+import jakarta.servlet.http.HttpServletRequest;
+import jakarta.servlet.http.HttpServletResponse;
 import jakarta.validation.Valid;
 import org.springframework.http.HttpStatus;
 import org.springframework.http.ResponseEntity;
+import org.springframework.security.core.AuthenticationException;
 import org.springframework.stereotype.Controller;
 import org.springframework.ui.Model;
 import org.springframework.validation.BindingResult;
@@ -51,6 +56,52 @@ public class AuthController {
             return "signup";
         }
         return "redirect:/signup?success=true";
+    }
+
+    @PostMapping("/api/auth/login")
+    @ResponseBody
+    public ResponseEntity<?> loginApi(
+            @Valid @RequestBody LoginRequest request, HttpServletRequest httpRequest) {
+        try {
+            TokenResponse token = authService.login(request);
+            return ResponseEntity.ok(token);
+        } catch (AuthenticationException ex) {
+            ErrorResponse body = ErrorResponse.of(
+                    HttpStatus.UNAUTHORIZED,
+                    "username과 password가 일치하지 않습니다",
+                    httpRequest.getRequestURI());
+            return ResponseEntity.status(HttpStatus.UNAUTHORIZED).body(body);
+        }
+    }
+
+    @GetMapping("/login")
+    public String loginForm(Model model) {
+        if (!model.containsAttribute("loginRequest")) {
+            model.addAttribute("loginRequest", new LoginRequest());
+        }
+        return "login";
+    }
+
+    @PostMapping("/login")
+    public String loginSubmit(
+            @Valid @ModelAttribute("loginRequest") LoginRequest loginRequest,
+            BindingResult bindingResult,
+            HttpServletResponse response) {
+        if (bindingResult.hasErrors()) {
+            return "login";
+        }
+        try {
+            TokenResponse token = authService.login(loginRequest);
+            Cookie cookie = new Cookie("accessToken", token.accessToken());
+            cookie.setHttpOnly(true);
+            cookie.setPath("/");
+            cookie.setMaxAge((int) token.expiresIn());
+            response.addCookie(cookie);
+            return "redirect:/login?success=true";
+        } catch (AuthenticationException ex) {
+            bindingResult.reject("login.invalid", "username과 password가 일치하지 않습니다");
+            return "login";
+        }
     }
 
     public record SignupResponse(Long id, String username) {

--- a/src/main/java/com/example/board/user/AuthService.java
+++ b/src/main/java/com/example/board/user/AuthService.java
@@ -1,5 +1,9 @@
 package com.example.board.user;
 
+import com.example.board.security.JwtTokenProvider;
+import org.springframework.security.authentication.AuthenticationManager;
+import org.springframework.security.authentication.UsernamePasswordAuthenticationToken;
+import org.springframework.security.core.Authentication;
 import org.springframework.security.crypto.password.PasswordEncoder;
 import org.springframework.stereotype.Service;
 import org.springframework.transaction.annotation.Transactional;
@@ -9,10 +13,18 @@ public class AuthService {
 
     private final UserRepository userRepository;
     private final PasswordEncoder passwordEncoder;
+    private final AuthenticationManager authenticationManager;
+    private final JwtTokenProvider jwtTokenProvider;
 
-    public AuthService(UserRepository userRepository, PasswordEncoder passwordEncoder) {
+    public AuthService(
+            UserRepository userRepository,
+            PasswordEncoder passwordEncoder,
+            AuthenticationManager authenticationManager,
+            JwtTokenProvider jwtTokenProvider) {
         this.userRepository = userRepository;
         this.passwordEncoder = passwordEncoder;
+        this.authenticationManager = authenticationManager;
+        this.jwtTokenProvider = jwtTokenProvider;
     }
 
     @Transactional
@@ -26,5 +38,13 @@ public class AuthService {
         }
         String hashed = passwordEncoder.encode(request.getPassword());
         return userRepository.save(new User(username, hashed));
+    }
+
+    public TokenResponse login(LoginRequest request) {
+        Authentication authentication = authenticationManager.authenticate(
+                new UsernamePasswordAuthenticationToken(request.getUsername(), request.getPassword()));
+        String accessToken = jwtTokenProvider.generateToken(authentication.getName());
+        long expiresInSeconds = jwtTokenProvider.getExpirationMs() / 1000;
+        return new TokenResponse(accessToken, "Bearer", expiresInSeconds);
     }
 }

--- a/src/main/java/com/example/board/user/LoginRequest.java
+++ b/src/main/java/com/example/board/user/LoginRequest.java
@@ -1,0 +1,36 @@
+package com.example.board.user;
+
+import jakarta.validation.constraints.NotBlank;
+
+public class LoginRequest {
+
+    @NotBlank(message = "username은 필수입니다")
+    private String username;
+
+    @NotBlank(message = "password는 필수입니다")
+    private String password;
+
+    public LoginRequest() {
+    }
+
+    public LoginRequest(String username, String password) {
+        this.username = username;
+        this.password = password;
+    }
+
+    public String getUsername() {
+        return username;
+    }
+
+    public void setUsername(String username) {
+        this.username = username;
+    }
+
+    public String getPassword() {
+        return password;
+    }
+
+    public void setPassword(String password) {
+        this.password = password;
+    }
+}

--- a/src/main/java/com/example/board/user/TokenResponse.java
+++ b/src/main/java/com/example/board/user/TokenResponse.java
@@ -1,0 +1,4 @@
+package com.example.board.user;
+
+public record TokenResponse(String accessToken, String tokenType, long expiresIn) {
+}

--- a/src/main/resources/templates/login.html
+++ b/src/main/resources/templates/login.html
@@ -1,0 +1,42 @@
+<!DOCTYPE html>
+<html lang="ko" xmlns:th="http://www.thymeleaf.org">
+<head>
+  <meta charset="UTF-8" />
+  <title>로그인</title>
+  <style>
+    body { font-family: sans-serif; max-width: 480px; margin: 48px auto; padding: 0 16px; }
+    h1 { margin-bottom: 24px; }
+    .field { margin-bottom: 16px; }
+    label { display: block; margin-bottom: 4px; font-weight: 600; }
+    input { width: 100%; padding: 8px; box-sizing: border-box; }
+    .error { color: #c00; font-size: 0.9em; margin-top: 4px; }
+    .success { color: #0a0; padding: 12px; background: #efe; margin-bottom: 16px; }
+    button { padding: 10px 20px; background: #06c; color: #fff; border: 0; cursor: pointer; }
+    button:hover { background: #05a; }
+  </style>
+</head>
+<body>
+<h1>로그인</h1>
+
+<div th:if="${param.success}" class="success">
+  로그인 성공! 액세스 토큰을 쿠키에 저장했습니다.
+</div>
+
+<form th:action="@{/login}" method="post" th:object="${loginRequest}">
+  <div class="field">
+    <label for="username">username</label>
+    <input type="text" id="username" th:field="*{username}" autocomplete="username" />
+    <div class="error" th:if="${#fields.hasErrors('username')}" th:errors="*{username}"></div>
+  </div>
+  <div class="field">
+    <label for="password">password</label>
+    <input type="password" id="password" th:field="*{password}" autocomplete="current-password" />
+    <div class="error" th:if="${#fields.hasErrors('password')}" th:errors="*{password}"></div>
+  </div>
+  <div class="error" th:if="${#fields.hasGlobalErrors()}">
+    <p th:each="err : ${#fields.globalErrors()}" th:text="${err}"></p>
+  </div>
+  <button type="submit">로그인</button>
+</form>
+</body>
+</html>

--- a/src/test/java/com/example/board/user/LoginControllerTest.java
+++ b/src/test/java/com/example/board/user/LoginControllerTest.java
@@ -1,0 +1,269 @@
+package com.example.board.user;
+
+import static org.hamcrest.Matchers.containsString;
+import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.get;
+import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.post;
+import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.content;
+import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.cookie;
+import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.header;
+import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.jsonPath;
+import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.status;
+
+import com.example.board.security.JwtTokenProvider;
+import io.jsonwebtoken.Jwts;
+import io.jsonwebtoken.security.Keys;
+import java.nio.charset.StandardCharsets;
+import java.util.Date;
+import java.util.Map;
+import javax.crypto.SecretKey;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Nested;
+import org.junit.jupiter.api.Test;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.beans.factory.annotation.Value;
+import org.springframework.boot.test.autoconfigure.web.servlet.AutoConfigureMockMvc;
+import org.springframework.boot.test.context.SpringBootTest;
+import org.springframework.context.annotation.Import;
+import org.springframework.http.MediaType;
+import org.springframework.security.core.Authentication;
+import org.springframework.security.crypto.password.PasswordEncoder;
+import org.springframework.test.context.ActiveProfiles;
+import org.springframework.test.web.servlet.MockMvc;
+import org.springframework.web.bind.annotation.GetMapping;
+import org.springframework.web.bind.annotation.RestController;
+
+@SpringBootTest
+@AutoConfigureMockMvc
+@ActiveProfiles("test")
+@Import(LoginControllerTest.ProbeController.class)
+class LoginControllerTest {
+
+    @Autowired
+    MockMvc mockMvc;
+
+    @Autowired
+    UserRepository userRepository;
+
+    @Autowired
+    PasswordEncoder passwordEncoder;
+
+    @Autowired
+    JwtTokenProvider jwtTokenProvider;
+
+    @Value("${app.jwt.secret}")
+    String jwtSecret;
+
+    @BeforeEach
+    void setUp() {
+        userRepository.deleteAll();
+        userRepository.save(new User("alice", passwordEncoder.encode("pw12345")));
+    }
+
+    @RestController
+    static class ProbeController {
+        @GetMapping("/probe/me")
+        public Map<String, Object> me(Authentication authentication) {
+            return Map.of("username", authentication.getName());
+        }
+    }
+
+    @Nested
+    class RestApi {
+
+        @Test
+        void 로그인_성공시_200과_accessToken_tokenType_expiresIn을_반환한다() throws Exception {
+            mockMvc.perform(post("/api/auth/login")
+                            .contentType(MediaType.APPLICATION_JSON)
+                            .content("{\"username\":\"alice\",\"password\":\"pw12345\"}"))
+                    .andExpect(status().isOk())
+                    .andExpect(jsonPath("$.accessToken").isString())
+                    .andExpect(jsonPath("$.tokenType").value("Bearer"))
+                    .andExpect(jsonPath("$.expiresIn").isNumber());
+        }
+
+        @Test
+        void 잘못된_password면_401과_ErrorResponse_본문을_반환한다() throws Exception {
+            mockMvc.perform(post("/api/auth/login")
+                            .contentType(MediaType.APPLICATION_JSON)
+                            .content("{\"username\":\"alice\",\"password\":\"wrong-password\"}"))
+                    .andExpect(status().isUnauthorized())
+                    .andExpect(jsonPath("$.status").value(401))
+                    .andExpect(jsonPath("$.error").value("Unauthorized"))
+                    .andExpect(jsonPath("$.message").exists())
+                    .andExpect(jsonPath("$.path").value("/api/auth/login"));
+        }
+
+        @Test
+        void 존재하지_않는_username이면_401을_반환한다() throws Exception {
+            mockMvc.perform(post("/api/auth/login")
+                            .contentType(MediaType.APPLICATION_JSON)
+                            .content("{\"username\":\"nobody\",\"password\":\"pw12345\"}"))
+                    .andExpect(status().isUnauthorized());
+        }
+
+        @Test
+        void username이_null이면_400을_반환하고_필드명을_포함한다() throws Exception {
+            mockMvc.perform(post("/api/auth/login")
+                            .contentType(MediaType.APPLICATION_JSON)
+                            .content("{\"password\":\"pw12345\"}"))
+                    .andExpect(status().isBadRequest())
+                    .andExpect(jsonPath("$.message").value(containsString("username")));
+        }
+
+        @Test
+        void password가_null이면_400을_반환하고_필드명을_포함한다() throws Exception {
+            mockMvc.perform(post("/api/auth/login")
+                            .contentType(MediaType.APPLICATION_JSON)
+                            .content("{\"username\":\"alice\"}"))
+                    .andExpect(status().isBadRequest())
+                    .andExpect(jsonPath("$.message").value(containsString("password")));
+        }
+
+        @Test
+        void username이_빈문자열이면_400을_반환한다() throws Exception {
+            mockMvc.perform(post("/api/auth/login")
+                            .contentType(MediaType.APPLICATION_JSON)
+                            .content("{\"username\":\"\",\"password\":\"pw12345\"}"))
+                    .andExpect(status().isBadRequest());
+        }
+
+        @Test
+        void password가_빈문자열이면_400을_반환한다() throws Exception {
+            mockMvc.perform(post("/api/auth/login")
+                            .contentType(MediaType.APPLICATION_JSON)
+                            .content("{\"username\":\"alice\",\"password\":\"\"}"))
+                    .andExpect(status().isBadRequest());
+        }
+    }
+
+    @Nested
+    class JwtFilter {
+
+        @Test
+        void 유효한_Bearer_토큰으로_보호엔드포인트_호출시_200과_username이_반환된다() throws Exception {
+            String token = jwtTokenProvider.generateToken("alice");
+            mockMvc.perform(get("/probe/me")
+                            .header("Authorization", "Bearer " + token))
+                    .andExpect(status().isOk())
+                    .andExpect(jsonPath("$.username").value("alice"));
+        }
+
+        @Test
+        void 토큰없이_보호엔드포인트_호출시_401이_반환된다() throws Exception {
+            mockMvc.perform(get("/probe/me"))
+                    .andExpect(status().isUnauthorized());
+        }
+
+        @Test
+        void Bearer_접두어_없이_토큰만_보내면_401이_반환된다() throws Exception {
+            String token = jwtTokenProvider.generateToken("alice");
+            mockMvc.perform(get("/probe/me")
+                            .header("Authorization", token))
+                    .andExpect(status().isUnauthorized());
+        }
+
+        @Test
+        void 변조된_토큰으로_호출시_401이_반환된다() throws Exception {
+            String token = jwtTokenProvider.generateToken("alice");
+            String tampered = token.substring(0, token.length() - 4) + "XXXX";
+            mockMvc.perform(get("/probe/me")
+                            .header("Authorization", "Bearer " + tampered))
+                    .andExpect(status().isUnauthorized());
+        }
+
+        @Test
+        void 만료된_토큰으로_호출시_401이_반환된다() throws Exception {
+            SecretKey key = Keys.hmacShaKeyFor(jwtSecret.getBytes(StandardCharsets.UTF_8));
+            Date past = new Date(System.currentTimeMillis() - 10_000);
+            String expiredToken = Jwts.builder()
+                    .subject("alice")
+                    .issuedAt(new Date(past.getTime() - 1000))
+                    .expiration(past)
+                    .signWith(key, Jwts.SIG.HS256)
+                    .compact();
+            mockMvc.perform(get("/probe/me")
+                            .header("Authorization", "Bearer " + expiredToken))
+                    .andExpect(status().isUnauthorized());
+        }
+
+        @Test
+        void 다른_서명키로_만든_토큰으로_호출시_401이_반환된다() throws Exception {
+            String otherSecret = "different-secret-different-secret-different-secret-64bytes!!!!!";
+            SecretKey wrongKey = Keys.hmacShaKeyFor(otherSecret.getBytes(StandardCharsets.UTF_8));
+            String foreignToken = Jwts.builder()
+                    .subject("alice")
+                    .issuedAt(new Date())
+                    .expiration(new Date(System.currentTimeMillis() + 60_000))
+                    .signWith(wrongKey, Jwts.SIG.HS256)
+                    .compact();
+            mockMvc.perform(get("/probe/me")
+                            .header("Authorization", "Bearer " + foreignToken))
+                    .andExpect(status().isUnauthorized());
+        }
+    }
+
+    @Nested
+    class View {
+
+        @Test
+        void GET_login은_로그인폼을_렌더한다() throws Exception {
+            mockMvc.perform(get("/login"))
+                    .andExpect(status().isOk())
+                    .andExpect(content().string(containsString("<form")))
+                    .andExpect(content().string(containsString("action=\"/login\"")))
+                    .andExpect(content().string(containsString("name=\"username\"")))
+                    .andExpect(content().string(containsString("name=\"password\"")))
+                    .andExpect(content().string(containsString("type=\"submit\"")));
+        }
+
+        @Test
+        void POST_login_정상입력시_302_redirect와_HttpOnly_accessToken_쿠키가_세팅된다() throws Exception {
+            mockMvc.perform(post("/login")
+                            .contentType(MediaType.APPLICATION_FORM_URLENCODED)
+                            .param("username", "alice")
+                            .param("password", "pw12345"))
+                    .andExpect(status().is3xxRedirection())
+                    .andExpect(header().string("Location", "/login?success=true"))
+                    .andExpect(cookie().exists("accessToken"))
+                    .andExpect(cookie().httpOnly("accessToken", true));
+        }
+
+        @Test
+        void POST_login_잘못된_password면_동일화면에_오류메시지가_렌더된다() throws Exception {
+            mockMvc.perform(post("/login")
+                            .contentType(MediaType.APPLICATION_FORM_URLENCODED)
+                            .param("username", "alice")
+                            .param("password", "wrong-password"))
+                    .andExpect(status().isOk())
+                    .andExpect(content().string(containsString("<form")))
+                    .andExpect(content().string(containsString("일치")));
+        }
+
+        @Test
+        void POST_login_존재하지_않는_username이면_동일화면에_오류메시지가_렌더된다() throws Exception {
+            mockMvc.perform(post("/login")
+                            .contentType(MediaType.APPLICATION_FORM_URLENCODED)
+                            .param("username", "nobody")
+                            .param("password", "pw12345"))
+                    .andExpect(status().isOk())
+                    .andExpect(content().string(containsString("<form")));
+        }
+
+        @Test
+        void POST_login_username_빈문자열이면_동일화면에_검증_오류가_렌더된다() throws Exception {
+            mockMvc.perform(post("/login")
+                            .contentType(MediaType.APPLICATION_FORM_URLENCODED)
+                            .param("username", "")
+                            .param("password", "pw12345"))
+                    .andExpect(status().isOk())
+                    .andExpect(content().string(containsString("username")));
+        }
+
+        @Test
+        void GET_login_success_파라미터시_성공메시지를_렌더한다() throws Exception {
+            mockMvc.perform(get("/login").param("success", "true"))
+                    .andExpect(status().isOk())
+                    .andExpect(content().string(containsString("로그인 성공")));
+        }
+    }
+}


### PR DESCRIPTION
Closes #8

## Summary
- JWT 인프라(`JwtTokenProvider`·`JwtAuthenticationFilter`·`CustomUserDetailsService`) 추가
- 로그인 REST API `POST /api/auth/login` 및 Thymeleaf 로그인 UI(`/login` GET/POST) 구현
- `SecurityConfig`에 `AuthenticationManager` 빈과 JWT 필터 등록, `/login` permitAll 추가

## TDD 증적
- **RED**: `test: #8 JWT 로그인 + 필터 + 로그인 UI 실패 테스트 추가` (`b558916`)
  - `LoginControllerTest` 19개 테스트 — `JwtTokenProvider` 스텁만 동반하여 16/19 실패 확인
- **GREEN**: `feat(auth): #8 JWT 인프라 + 로그인 API + 로그인 UI 구현 (2.2)` (`e7b0b0c`)
  - 전체 테스트 통과 + JaCoCo 95% 임계 통과

### RED에서 선제 설계한 edge case
- 입력 검증: username/password null, 빈 문자열
- 자격 실패: 잘못된 password, 존재하지 않는 username
- 토큰 실패: 토큰 없음, `Bearer` 접두어 누락, 변조된 토큰, 만료된 토큰, 다른 서명 키로 만든 토큰
- 부수효과: 폼 로그인 성공 시 `HttpOnly` 쿠키 `accessToken` 세팅

## Test plan
- [x] `./gradlew clean build` 로컬 초록불 (전체 38 tests PASS, 커버리지 95% 이상)
- [x] 수동 검증 — `bootRun` 후 curl 10개 시나리오 (signup → login REST/폼, edge case, 성공 메시지, HttpOnly 쿠키) 전부 예상대로 동작
- [x] CI 초록불 — [`Test + Coverage`](https://github.com/marcosdeseul/dihisoft-claude-session/actions/runs/24763455075/job/72452119142) (1m16s) + [`Build (no tests)`](https://github.com/marcosdeseul/dihisoft-claude-session/actions/runs/24763455075/job/72452119137) (32s) 모두 pass
- [ ] (선택) Playwright MCP 세션 재적재 후 실제 브라우저 스크린샷 증적

## 파일 변경 요약 (10개)
| # | 파일 | 구분 | 비고 |
|---|---|---|---|
| 1 | `src/main/java/com/example/board/security/JwtTokenProvider.java` | 신규 | HS256, `generateToken`·`resolveUsername` |
| 2 | `src/main/java/com/example/board/security/JwtAuthenticationFilter.java` | 신규 | `OncePerRequestFilter`, Bearer → `SecurityContext` |
| 3 | `src/main/java/com/example/board/security/CustomUserDetailsService.java` | 신규 | `UserRepository.findByUsername` 위임 |
| 4 | `src/main/java/com/example/board/user/LoginRequest.java` | 신규 | `@NotBlank` DTO |
| 5 | `src/main/java/com/example/board/user/TokenResponse.java` | 신규 | `record(accessToken, tokenType, expiresIn)` |
| 6 | `src/main/java/com/example/board/user/AuthService.java` | 수정 | `login(LoginRequest)` 추가 |
| 7 | `src/main/java/com/example/board/user/AuthController.java` | 수정 | REST `/api/auth/login` + 폼 `/login` GET·POST |
| 8 | `src/main/java/com/example/board/config/SecurityConfig.java` | 수정 | `AuthenticationManager` 빈 + `addFilterBefore` + `/login` permitAll |
| 9 | `src/main/resources/templates/login.html` | 신규 | Thymeleaf 로그인 폼 |
| 10 | `src/test/java/com/example/board/user/LoginControllerTest.java` | 신규 | `@Nested` (RestApi·JwtFilter·View) 19 케이스, 내부 `@TestConfiguration` 로 `/probe/me` 프로브 |

## 주의
- 이슈 #8 은 다른 참가자(kms·JY)들에 의해 서브이슈(#13/#14, #17/#18)로 분할된 상태이지만, 본 PR(reposy)은 **#8 전체 scope를 단일 PR(10파일)로 구현**. #8 본문의 다른 참가자 체크박스는 건드리지 않음.
- `CustomUserDetailsService` 는 Spring Security의 자동 `DaoAuthenticationProvider` 구성을 위해 별도 등록 없이 `@Service` + `PasswordEncoder` 빈만으로 동작.
- JJWT 0.12.6 API 사용(`Jwts.builder().subject(...).signWith(key, Jwts.SIG.HS256)`, `Jwts.parser().verifyWith(key)...`).
- 필터 테스트는 실제 보호 엔드포인트가 아직 없어 `@TestConfiguration` 로 `/probe/me` 프로브를 등록해 커버 — 파일 수를 10개로 유지.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
