### PR TITLE
refactor(auth): #27 TDD 결손 보완 + Auth 레이어 재정비

### DIFF
--- a/src/main/java/com/example/board/common/GlobalExceptionHandler.java
+++ b/src/main/java/com/example/board/common/GlobalExceptionHandler.java
@@ -1,5 +1,6 @@
 package com.example.board.common;
 
+import com.example.board.user.AuthErrorMessages;
 import jakarta.servlet.http.HttpServletRequest;
 import java.util.stream.Collectors;
 import org.slf4j.Logger;
@@ -7,6 +8,7 @@ import org.slf4j.LoggerFactory;
 import org.springframework.http.HttpStatus;
 import org.springframework.http.ResponseEntity;
 import org.springframework.security.access.AccessDeniedException;
+import org.springframework.security.core.AuthenticationException;
 import org.springframework.web.bind.MethodArgumentNotValidException;
 import org.springframework.web.bind.annotation.ExceptionHandler;
 import org.springframework.web.bind.annotation.RestControllerAdvice;
@@ -36,6 +38,12 @@ public class GlobalExceptionHandler {
     public ResponseEntity<ErrorResponse> handleAccessDenied(
             AccessDeniedException ex, HttpServletRequest request) {
         return respond(HttpStatus.FORBIDDEN, "접근이 거부되었습니다", request);
+    }
+
+    @ExceptionHandler(AuthenticationException.class)
+    public ResponseEntity<ErrorResponse> handleAuthentication(
+            AuthenticationException ex, HttpServletRequest request) {
+        return respond(HttpStatus.UNAUTHORIZED, AuthErrorMessages.INVALID_CREDENTIALS, request);
     }
 
     @ExceptionHandler(IllegalArgumentException.class)

--- a/src/main/java/com/example/board/security/JwtAuthenticationFilter.java
+++ b/src/main/java/com/example/board/security/JwtAuthenticationFilter.java
@@ -6,6 +6,8 @@ import jakarta.servlet.http.HttpServletRequest;
 import jakarta.servlet.http.HttpServletResponse;
 import java.io.IOException;
 import java.util.Optional;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
 import org.springframework.security.authentication.UsernamePasswordAuthenticationToken;
 import org.springframework.security.core.context.SecurityContextHolder;
 import org.springframework.security.core.userdetails.UserDetails;
@@ -17,6 +19,8 @@ import org.springframework.web.filter.OncePerRequestFilter;
 
 @Component
 public class JwtAuthenticationFilter extends OncePerRequestFilter {
+
+    private static final Logger log = LoggerFactory.getLogger(JwtAuthenticationFilter.class);
 
     private static final String HEADER = "Authorization";
     private static final String BEARER_PREFIX = "Bearer ";
@@ -45,8 +49,8 @@ public class JwtAuthenticationFilter extends OncePerRequestFilter {
                                     userDetails, null, userDetails.getAuthorities());
                     authentication.setDetails(new WebAuthenticationDetailsSource().buildDetails(request));
                     SecurityContextHolder.getContext().setAuthentication(authentication);
-                } catch (UsernameNotFoundException ignored) {
-                    // 토큰은 유효하나 사용자 미존재: 컨텍스트 미주입 → 이후 EntryPoint가 401 처리
+                } catch (UsernameNotFoundException ex) {
+                    log.debug("JWT 유효하지만 사용자 미존재: {}", username.get());
                 }
             }
         }

--- a/src/main/java/com/example/board/user/AuthErrorMessages.java
+++ b/src/main/java/com/example/board/user/AuthErrorMessages.java
@@ -1,0 +1,9 @@
+package com.example.board.user;
+
+public final class AuthErrorMessages {
+
+    public static final String INVALID_CREDENTIALS = "username과 password가 일치하지 않습니다";
+
+    private AuthErrorMessages() {
+    }
+}

--- a/src/main/java/com/example/board/user/AuthRestController.java
+++ b/src/main/java/com/example/board/user/AuthRestController.java
@@ -1,0 +1,35 @@
+package com.example.board.user;
+
+import jakarta.validation.Valid;
+import org.springframework.http.HttpStatus;
+import org.springframework.http.ResponseEntity;
+import org.springframework.web.bind.annotation.PostMapping;
+import org.springframework.web.bind.annotation.RequestBody;
+import org.springframework.web.bind.annotation.RequestMapping;
+import org.springframework.web.bind.annotation.RestController;
+
+@RestController
+@RequestMapping("/api/auth")
+public class AuthRestController {
+
+    private final AuthService authService;
+
+    public AuthRestController(AuthService authService) {
+        this.authService = authService;
+    }
+
+    @PostMapping("/signup")
+    public ResponseEntity<SignupResponse> signup(@Valid @RequestBody SignupRequest request) {
+        User user = authService.signup(request);
+        return ResponseEntity.status(HttpStatus.CREATED)
+                .body(new SignupResponse(user.getId(), user.getUsername()));
+    }
+
+    @PostMapping("/login")
+    public ResponseEntity<TokenResponse> login(@Valid @RequestBody LoginRequest request) {
+        return ResponseEntity.ok(authService.login(request));
+    }
+
+    public record SignupResponse(Long id, String username) {
+    }
+}

--- a/src/main/java/com/example/board/user/AuthViewController.java
+++ b/src/main/java/com/example/board/user/AuthViewController.java
@@ -1,12 +1,8 @@
 package com.example.board.user;
 
-import com.example.board.common.ErrorResponse;
 import jakarta.servlet.http.Cookie;
-import jakarta.servlet.http.HttpServletRequest;
 import jakarta.servlet.http.HttpServletResponse;
 import jakarta.validation.Valid;
-import org.springframework.http.HttpStatus;
-import org.springframework.http.ResponseEntity;
 import org.springframework.security.core.AuthenticationException;
 import org.springframework.stereotype.Controller;
 import org.springframework.ui.Model;
@@ -14,24 +10,14 @@ import org.springframework.validation.BindingResult;
 import org.springframework.web.bind.annotation.GetMapping;
 import org.springframework.web.bind.annotation.ModelAttribute;
 import org.springframework.web.bind.annotation.PostMapping;
-import org.springframework.web.bind.annotation.RequestBody;
-import org.springframework.web.bind.annotation.ResponseBody;
 
 @Controller
-public class AuthController {
+public class AuthViewController {
 
     private final AuthService authService;
 
-    public AuthController(AuthService authService) {
+    public AuthViewController(AuthService authService) {
         this.authService = authService;
-    }
-
-    @PostMapping("/api/auth/signup")
-    @ResponseBody
-    public ResponseEntity<SignupResponse> signupApi(@Valid @RequestBody SignupRequest request) {
-        User user = authService.signup(request);
-        return ResponseEntity.status(HttpStatus.CREATED)
-                .body(new SignupResponse(user.getId(), user.getUsername()));
     }
 
     @GetMapping("/signup")
@@ -56,22 +42,6 @@ public class AuthController {
             return "signup";
         }
         return "redirect:/signup?success=true";
-    }
-
-    @PostMapping("/api/auth/login")
-    @ResponseBody
-    public ResponseEntity<?> loginApi(
-            @Valid @RequestBody LoginRequest request, HttpServletRequest httpRequest) {
-        try {
-            TokenResponse token = authService.login(request);
-            return ResponseEntity.ok(token);
-        } catch (AuthenticationException ex) {
-            ErrorResponse body = ErrorResponse.of(
-                    HttpStatus.UNAUTHORIZED,
-                    "username과 password가 일치하지 않습니다",
-                    httpRequest.getRequestURI());
-            return ResponseEntity.status(HttpStatus.UNAUTHORIZED).body(body);
-        }
     }
 
     @GetMapping("/login")
@@ -99,11 +69,8 @@ public class AuthController {
             response.addCookie(cookie);
             return "redirect:/login?success=true";
         } catch (AuthenticationException ex) {
-            bindingResult.reject("login.invalid", "username과 password가 일치하지 않습니다");
+            bindingResult.reject("login.invalid", AuthErrorMessages.INVALID_CREDENTIALS);
             return "login";
         }
-    }
-
-    public record SignupResponse(Long id, String username) {
     }
 }

--- a/src/test/java/com/example/board/security/CustomUserDetailsServiceTest.java
+++ b/src/test/java/com/example/board/security/CustomUserDetailsServiceTest.java
@@ -1,0 +1,53 @@
+package com.example.board.security;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.assertj.core.api.Assertions.assertThatThrownBy;
+
+import com.example.board.user.User;
+import com.example.board.user.UserRepository;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.boot.test.context.SpringBootTest;
+import org.springframework.security.core.userdetails.UserDetails;
+import org.springframework.security.core.userdetails.UsernameNotFoundException;
+import org.springframework.security.crypto.password.PasswordEncoder;
+import org.springframework.test.context.ActiveProfiles;
+
+@SpringBootTest
+@ActiveProfiles("test")
+class CustomUserDetailsServiceTest {
+
+    @Autowired
+    CustomUserDetailsService customUserDetailsService;
+
+    @Autowired
+    UserRepository userRepository;
+
+    @Autowired
+    PasswordEncoder passwordEncoder;
+
+    @BeforeEach
+    void cleanDb() {
+        userRepository.deleteAll();
+    }
+
+    @Test
+    void loadUserByUsername_존재하는_사용자면_저장된_username과_해시된_password를_담은_UserDetails를_반환한다() {
+        String hashed = passwordEncoder.encode("pw12345");
+        userRepository.save(new User("uds_alice", hashed));
+
+        UserDetails details = customUserDetailsService.loadUserByUsername("uds_alice");
+
+        assertThat(details.getUsername()).isEqualTo("uds_alice");
+        assertThat(details.getPassword()).isEqualTo(hashed);
+        assertThat(details.getAuthorities()).isEmpty();
+    }
+
+    @Test
+    void loadUserByUsername_미존재_username이면_UsernameNotFoundException이_발생한다() {
+        assertThatThrownBy(() -> customUserDetailsService.loadUserByUsername("uds_nobody"))
+                .isInstanceOf(UsernameNotFoundException.class)
+                .hasMessageContaining("uds_nobody");
+    }
+}

--- a/src/test/java/com/example/board/user/AuthServiceTest.java
+++ b/src/test/java/com/example/board/user/AuthServiceTest.java
@@ -3,10 +3,12 @@ package com.example.board.user;
 import static org.assertj.core.api.Assertions.assertThat;
 import static org.assertj.core.api.Assertions.assertThatThrownBy;
 
+import com.example.board.security.JwtTokenProvider;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.boot.test.context.SpringBootTest;
+import org.springframework.security.core.AuthenticationException;
 import org.springframework.test.context.ActiveProfiles;
 
 @SpringBootTest
@@ -18,6 +20,9 @@ class AuthServiceTest {
 
     @Autowired
     UserRepository userRepository;
+
+    @Autowired
+    JwtTokenProvider jwtTokenProvider;
 
     @BeforeEach
     void cleanDb() {
@@ -67,5 +72,31 @@ class AuthServiceTest {
         User saved = authService.signup(new SignupRequest("  alice_trim  ", "pw12345"));
 
         assertThat(saved.getUsername()).isEqualTo("alice_trim");
+    }
+
+    @Test
+    void login_정상입력시_TokenResponse의_accessToken_tokenType_expiresIn이_채워진다() {
+        authService.signup(new SignupRequest("login_ok", "pw12345"));
+
+        TokenResponse token = authService.login(new LoginRequest("login_ok", "pw12345"));
+
+        assertThat(token.accessToken()).isNotBlank();
+        assertThat(token.tokenType()).isEqualTo("Bearer");
+        assertThat(token.expiresIn()).isEqualTo(jwtTokenProvider.getExpirationMs() / 1000);
+        assertThat(jwtTokenProvider.resolveUsername(token.accessToken())).contains("login_ok");
+    }
+
+    @Test
+    void login_잘못된_password면_AuthenticationException이_발생한다() {
+        authService.signup(new SignupRequest("login_badpw", "pw12345"));
+
+        assertThatThrownBy(() -> authService.login(new LoginRequest("login_badpw", "wrong-password")))
+                .isInstanceOf(AuthenticationException.class);
+    }
+
+    @Test
+    void login_존재하지_않는_username이면_AuthenticationException이_발생한다() {
+        assertThatThrownBy(() -> authService.login(new LoginRequest("nobody_srv", "pw12345")))
+                .isInstanceOf(AuthenticationException.class);
     }
 }

--- a/src/test/java/com/example/board/user/LoginControllerTest.java
+++ b/src/test/java/com/example/board/user/LoginControllerTest.java
@@ -134,6 +134,15 @@ class LoginControllerTest {
                             .content("{\"username\":\"alice\",\"password\":\"\"}"))
                     .andExpect(status().isBadRequest());
         }
+
+        @Test
+        void username이_공백만이면_400을_반환하고_필드명을_포함한다() throws Exception {
+            mockMvc.perform(post("/api/auth/login")
+                            .contentType(MediaType.APPLICATION_JSON)
+                            .content("{\"username\":\"   \",\"password\":\"pw12345\"}"))
+                    .andExpect(status().isBadRequest())
+                    .andExpect(jsonPath("$.message").value(containsString("username")));
+        }
     }
 
     @Nested
@@ -183,6 +192,28 @@ class LoginControllerTest {
                     .compact();
             mockMvc.perform(get("/probe/me")
                             .header("Authorization", "Bearer " + expiredToken))
+                    .andExpect(status().isUnauthorized());
+        }
+
+        @Test
+        void 서명은_유효하지만_sub_claim이_없는_토큰으로_호출시_401이_반환된다() throws Exception {
+            SecretKey key = Keys.hmacShaKeyFor(jwtSecret.getBytes(StandardCharsets.UTF_8));
+            String noSubjectToken = Jwts.builder()
+                    .issuedAt(new Date())
+                    .expiration(new Date(System.currentTimeMillis() + 60_000))
+                    .signWith(key, Jwts.SIG.HS256)
+                    .compact();
+            mockMvc.perform(get("/probe/me")
+                            .header("Authorization", "Bearer " + noSubjectToken))
+                    .andExpect(status().isUnauthorized());
+        }
+
+        @Test
+        void 유효한_토큰이지만_사용자가_DB에서_삭제됐으면_401이_반환된다() throws Exception {
+            String token = jwtTokenProvider.generateToken("alice");
+            userRepository.deleteAll();
+            mockMvc.perform(get("/probe/me")
+                            .header("Authorization", "Bearer " + token))
                     .andExpect(status().isUnauthorized());
         }
 


### PR DESCRIPTION
Closes #27

## Summary
- PR #21 리뷰에서 드러난 **TDD 결손**(edge case 테스트 0건 분기, 단위 테스트 부재) 을 메우고 Auth 레이어를 CLAUDE.md "책임 분리 / 에러 매핑 일원화" 기준으로 재정비
- **기능 변화 없음** — 기존 LoginControllerTest/SignupControllerTest 가 회귀 가드로 동작

## TDD 증적

4개 커밋으로 사이클 분리:

| 커밋 | 단계 | 내용 |
|---|---|---|
| `eed8d63` | **test (RED)** | 누락 edge case 3종 회귀 방지 테스트 |
| `7b03106` | **feat (GREEN)** | JWT 필터 `// ignored` 분기 → `log.debug` 명문화 |
| `7f4473d` | **test** | AuthService.login · CustomUserDetailsService 단위 테스트 |
| `9c45e32` | **refactor** | AuthController 분리 + 에러 매핑 이관 + 상수 추출 |

### RED에서 선제 설계한 edge case
- **인증/권한**: 서명 유효 + `sub` claim 누락 토큰 → 401
- **리소스 상태**: 유효 토큰 발급 후 사용자 DB에서 삭제 → 401 (필터 `UsernameNotFoundException` 분기가 처음으로 테스트로 커버)
- **입력 검증**: `/api/auth/login` username 공백-only (`"   "`) → 400 (`@NotBlank` whitespace-only 계약)

## Test plan
- [x] `./gradlew clean build` 로컬 초록불 (61 tests PASS, INSTRUCTION 커버리지 **99.11%**)
- [x] CI 초록불 — [Test + Coverage pass 1m5s](https://github.com/marcosdeseul/dihisoft-claude-session/actions/runs/24767694456/job/72465866177) · [Build (no tests) pass 27s](https://github.com/marcosdeseul/dihisoft-claude-session/actions/runs/24767694456/job/72465866192)

## 파일 변경 요약 (총 8개, ≤10 준수)

| # | 파일 | 구분 | 비고 |
|---|---|---|---|
| 1 | `user/AuthRestController.java` | 신규 | `@RestController` · `/api/auth/**` |
| 2 | `user/AuthViewController.java` | 신규 (AuthController rename) | `@Controller` · `/login`, `/signup` |
| 3 | `user/AuthErrorMessages.java` | 신규 | `INVALID_CREDENTIALS` 상수 |
| 4 | `common/GlobalExceptionHandler.java` | 수정 | `AuthenticationException` 핸들러 이관 |
| 5 | `security/JwtAuthenticationFilter.java` | 수정 | `// ignored` → `log.debug` |
| 6 | `test/.../LoginControllerTest.java` | 수정 | edge case 3종 추가 |
| 7 | `test/.../AuthServiceTest.java` | 수정 | login 3종 추가 |
| 8 | `test/.../security/CustomUserDetailsServiceTest.java` | 신규 | 2종 |

신규 파일 모두 < 100 라인 (300줄 제한 준수).

## 설계 포인트 — EntryPoint vs GlobalExceptionHandler
- `RestAuthenticationEntryPoint` 는 **보호 엔드포인트 미인증** 진입 시 호출 (기존 동작 유지)
- `GlobalExceptionHandler.handleAuthentication` 은 **permitAll 경로** (`/api/auth/login`) 에서 `AuthenticationManager` 가 던진 예외 캐치 → 역할 충돌 없음

## 주의
- 의존: #8 (merge 완료)
- 이 PR은 **기능 변화 0** — 동작이 바뀌었다면 리팩터 실패이므로 기존 통합 테스트 초록불 여부가 핵심 지표

🤖 Generated with [Claude Code](https://claude.com/claude-code)
