### PR TITLE
feat(post): #4 게시글 CRUD — 조회/작성/수정/삭제 + 본인 확인

### DIFF
--- a/src/main/java/com/example/board/common/GlobalExceptionHandler.java
+++ b/src/main/java/com/example/board/common/GlobalExceptionHandler.java
@@ -10,6 +10,7 @@ import org.springframework.security.access.AccessDeniedException;
 import org.springframework.web.bind.MethodArgumentNotValidException;
 import org.springframework.web.bind.annotation.ExceptionHandler;
 import org.springframework.web.bind.annotation.RestControllerAdvice;
+import org.springframework.web.server.ResponseStatusException;
 import org.springframework.web.servlet.NoHandlerFoundException;
 
 @RestControllerAdvice
@@ -30,6 +31,14 @@ public class GlobalExceptionHandler {
     public ResponseEntity<ErrorResponse> handleNotFound(
             NoHandlerFoundException ex, HttpServletRequest request) {
         return respond(HttpStatus.NOT_FOUND, "요청한 리소스를 찾을 수 없습니다", request);
+    }
+
+    @ExceptionHandler(ResponseStatusException.class)
+    public ResponseEntity<ErrorResponse> handleResponseStatus(
+            ResponseStatusException ex, HttpServletRequest request) {
+        HttpStatus status = HttpStatus.valueOf(ex.getStatusCode().value());
+        String message = ex.getReason() != null ? ex.getReason() : status.getReasonPhrase();
+        return respond(status, message, request);
     }
 
     @ExceptionHandler(AccessDeniedException.class)

--- a/src/main/java/com/example/board/config/SecurityConfig.java
+++ b/src/main/java/com/example/board/config/SecurityConfig.java
@@ -3,6 +3,7 @@ package com.example.board.config;
 import com.example.board.security.JwtAuthenticationFilter;
 import org.springframework.context.annotation.Bean;
 import org.springframework.context.annotation.Configuration;
+import org.springframework.http.HttpMethod;
 import org.springframework.security.authentication.AuthenticationManager;
 import org.springframework.security.config.annotation.authentication.configuration.AuthenticationConfiguration;
 import org.springframework.security.config.annotation.web.builders.HttpSecurity;
@@ -53,6 +54,7 @@ public class SecurityConfig {
                         .requestMatchers(AntPathRequestMatcher.antMatcher("/login")).permitAll()
                         .requestMatchers(AntPathRequestMatcher.antMatcher("/css/**")).permitAll()
                         .requestMatchers(AntPathRequestMatcher.antMatcher("/webjars/**")).permitAll()
+                        .requestMatchers(HttpMethod.GET, "/api/posts", "/api/posts/*").permitAll()
                         .anyRequest().authenticated())
                 .exceptionHandling(ex -> ex
                         .authenticationEntryPoint(authenticationEntryPoint)

--- a/src/main/java/com/example/board/post/Post.java
+++ b/src/main/java/com/example/board/post/Post.java
@@ -1,0 +1,68 @@
+package com.example.board.post;
+
+import com.example.board.common.BaseEntity;
+import com.example.board.user.User;
+import jakarta.persistence.Column;
+import jakarta.persistence.Entity;
+import jakarta.persistence.FetchType;
+import jakarta.persistence.GeneratedValue;
+import jakarta.persistence.GenerationType;
+import jakarta.persistence.Id;
+import jakarta.persistence.JoinColumn;
+import jakarta.persistence.Lob;
+import jakarta.persistence.ManyToOne;
+import jakarta.persistence.Table;
+
+@Entity
+@Table(name = "posts")
+public class Post extends BaseEntity {
+
+    @Id
+    @GeneratedValue(strategy = GenerationType.IDENTITY)
+    private Long id;
+
+    @Column(nullable = false, length = 100)
+    private String title;
+
+    @Lob
+    @Column(nullable = false)
+    private String content;
+
+    @ManyToOne(fetch = FetchType.LAZY, optional = false)
+    @JoinColumn(name = "author_id", nullable = false)
+    private User author;
+
+    protected Post() {
+    }
+
+    public Post(String title, String content, User author) {
+        this.title = title;
+        this.content = content;
+        this.author = author;
+    }
+
+    public void update(String title, String content) {
+        this.title = title;
+        this.content = content;
+    }
+
+    public boolean isOwnedBy(String username) {
+        return author != null && author.getUsername().equals(username);
+    }
+
+    public Long getId() {
+        return id;
+    }
+
+    public String getTitle() {
+        return title;
+    }
+
+    public String getContent() {
+        return content;
+    }
+
+    public User getAuthor() {
+        return author;
+    }
+}

--- a/src/main/java/com/example/board/post/PostController.java
+++ b/src/main/java/com/example/board/post/PostController.java
@@ -1,0 +1,69 @@
+package com.example.board.post;
+
+import jakarta.validation.Valid;
+import org.springframework.data.domain.PageRequest;
+import org.springframework.http.HttpStatus;
+import org.springframework.security.core.Authentication;
+import org.springframework.web.bind.annotation.DeleteMapping;
+import org.springframework.web.bind.annotation.GetMapping;
+import org.springframework.web.bind.annotation.PathVariable;
+import org.springframework.web.bind.annotation.PostMapping;
+import org.springframework.web.bind.annotation.PutMapping;
+import org.springframework.web.bind.annotation.RequestBody;
+import org.springframework.web.bind.annotation.RequestMapping;
+import org.springframework.web.bind.annotation.RequestParam;
+import org.springframework.web.bind.annotation.ResponseStatus;
+import org.springframework.web.bind.annotation.RestController;
+
+@RestController
+@RequestMapping("/api/posts")
+public class PostController {
+
+    private final PostService postService;
+
+    public PostController(PostService postService) {
+        this.postService = postService;
+    }
+
+    @GetMapping
+    public PostResponse.PageResponse<PostResponse> list(
+            @RequestParam(defaultValue = "0") int page,
+            @RequestParam(defaultValue = "10") int size) {
+        if (page < 0) {
+            throw new IllegalArgumentException("page는 0 이상이어야 합니다");
+        }
+        if (size <= 0) {
+            throw new IllegalArgumentException("size는 1 이상이어야 합니다");
+        }
+        return PostResponse.PageResponse.from(
+                postService.list(PageRequest.of(page, size)).map(PostResponse::from));
+    }
+
+    @GetMapping("/{id}")
+    public PostResponse get(@PathVariable Long id) {
+        return PostResponse.from(postService.get(id));
+    }
+
+    @PostMapping
+    @ResponseStatus(HttpStatus.CREATED)
+    public PostResponse create(
+            @Valid @RequestBody PostWriteRequest.Create request, Authentication authentication) {
+        return PostResponse.from(
+                postService.create(request.title(), request.content(), authentication.getName()));
+    }
+
+    @PutMapping("/{id}")
+    public PostResponse update(
+            @PathVariable Long id,
+            @Valid @RequestBody PostWriteRequest.Update request,
+            Authentication authentication) {
+        return PostResponse.from(
+                postService.update(id, request.title(), request.content(), authentication.getName()));
+    }
+
+    @DeleteMapping("/{id}")
+    @ResponseStatus(HttpStatus.NO_CONTENT)
+    public void delete(@PathVariable Long id, Authentication authentication) {
+        postService.delete(id, authentication.getName());
+    }
+}

--- a/src/main/java/com/example/board/post/PostRepository.java
+++ b/src/main/java/com/example/board/post/PostRepository.java
@@ -1,0 +1,17 @@
+package com.example.board.post;
+
+import java.util.Optional;
+import org.springframework.data.domain.Page;
+import org.springframework.data.domain.Pageable;
+import org.springframework.data.jpa.repository.EntityGraph;
+import org.springframework.data.jpa.repository.JpaRepository;
+
+public interface PostRepository extends JpaRepository<Post, Long> {
+
+    @EntityGraph(attributePaths = "author")
+    Page<Post> findAllByOrderByCreatedAtDesc(Pageable pageable);
+
+    @Override
+    @EntityGraph(attributePaths = "author")
+    Optional<Post> findById(Long id);
+}

--- a/src/main/java/com/example/board/post/PostResponse.java
+++ b/src/main/java/com/example/board/post/PostResponse.java
@@ -1,0 +1,41 @@
+package com.example.board.post;
+
+import java.time.Instant;
+import java.util.List;
+import org.springframework.data.domain.Page;
+
+public record PostResponse(
+        Long id,
+        String title,
+        String content,
+        String authorUsername,
+        Instant createdAt,
+        Instant updatedAt) {
+
+    public static PostResponse from(Post post) {
+        return new PostResponse(
+                post.getId(),
+                post.getTitle(),
+                post.getContent(),
+                post.getAuthor().getUsername(),
+                post.getCreatedAt(),
+                post.getUpdatedAt());
+    }
+
+    public record PageResponse<T>(
+            List<T> content,
+            int page,
+            int size,
+            long totalElements,
+            int totalPages) {
+
+        public static <T> PageResponse<T> from(Page<T> page) {
+            return new PageResponse<>(
+                    page.getContent(),
+                    page.getNumber(),
+                    page.getSize(),
+                    page.getTotalElements(),
+                    page.getTotalPages());
+        }
+    }
+}

--- a/src/main/java/com/example/board/post/PostService.java
+++ b/src/main/java/com/example/board/post/PostService.java
@@ -1,0 +1,62 @@
+package com.example.board.post;
+
+import com.example.board.user.User;
+import com.example.board.user.UserRepository;
+import org.springframework.data.domain.Page;
+import org.springframework.data.domain.Pageable;
+import org.springframework.http.HttpStatus;
+import org.springframework.security.access.AccessDeniedException;
+import org.springframework.stereotype.Service;
+import org.springframework.transaction.annotation.Transactional;
+import org.springframework.web.server.ResponseStatusException;
+
+@Service
+@Transactional
+public class PostService {
+
+    private final PostRepository postRepository;
+    private final UserRepository userRepository;
+
+    public PostService(PostRepository postRepository, UserRepository userRepository) {
+        this.postRepository = postRepository;
+        this.userRepository = userRepository;
+    }
+
+    @Transactional(readOnly = true)
+    public Page<Post> list(Pageable pageable) {
+        return postRepository.findAllByOrderByCreatedAtDesc(pageable);
+    }
+
+    @Transactional(readOnly = true)
+    public Post get(Long id) {
+        return postRepository.findById(id)
+                .orElseThrow(() -> new ResponseStatusException(
+                        HttpStatus.NOT_FOUND, "게시글을 찾을 수 없습니다: " + id));
+    }
+
+    public Post create(String title, String content, String username) {
+        User author = userRepository.findByUsername(username)
+                .orElseThrow(() -> new ResponseStatusException(
+                        HttpStatus.NOT_FOUND, "사용자를 찾을 수 없습니다: " + username));
+        return postRepository.save(new Post(title, content, author));
+    }
+
+    public Post update(Long id, String title, String content, String username) {
+        Post post = get(id);
+        assertOwnedBy(post, username);
+        post.update(title, content);
+        return post;
+    }
+
+    public void delete(Long id, String username) {
+        Post post = get(id);
+        assertOwnedBy(post, username);
+        postRepository.delete(post);
+    }
+
+    private void assertOwnedBy(Post post, String username) {
+        if (!post.isOwnedBy(username)) {
+            throw new AccessDeniedException("본인의 글만 수정/삭제할 수 있습니다");
+        }
+    }
+}

--- a/src/main/java/com/example/board/post/PostWriteRequest.java
+++ b/src/main/java/com/example/board/post/PostWriteRequest.java
@@ -1,0 +1,28 @@
+package com.example.board.post;
+
+import jakarta.validation.constraints.NotBlank;
+import jakarta.validation.constraints.Size;
+
+public final class PostWriteRequest {
+
+    private PostWriteRequest() {
+    }
+
+    public record Create(
+            @NotBlank(message = "title은 필수입니다")
+            @Size(max = 100, message = "title은 최대 100자입니다")
+            String title,
+
+            @NotBlank(message = "content는 필수입니다")
+            String content) {
+    }
+
+    public record Update(
+            @NotBlank(message = "title은 필수입니다")
+            @Size(max = 100, message = "title은 최대 100자입니다")
+            String title,
+
+            @NotBlank(message = "content는 필수입니다")
+            String content) {
+    }
+}

--- a/src/test/java/com/example/board/post/PostCrudControllerTest.java
+++ b/src/test/java/com/example/board/post/PostCrudControllerTest.java
@@ -1,0 +1,289 @@
+package com.example.board.post;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.hamcrest.Matchers.containsString;
+import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.delete;
+import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.get;
+import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.post;
+import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.put;
+import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.jsonPath;
+import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.status;
+
+import com.example.board.security.JwtTokenProvider;
+import com.example.board.user.User;
+import com.example.board.user.UserRepository;
+import org.junit.jupiter.api.AfterEach;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.boot.test.autoconfigure.web.servlet.AutoConfigureMockMvc;
+import org.springframework.boot.test.context.SpringBootTest;
+import org.springframework.http.MediaType;
+import org.springframework.security.crypto.password.PasswordEncoder;
+import org.springframework.test.context.ActiveProfiles;
+import org.springframework.test.web.servlet.MockMvc;
+
+@SpringBootTest
+@AutoConfigureMockMvc
+@ActiveProfiles("test")
+class PostCrudControllerTest {
+
+    @Autowired MockMvc mockMvc;
+    @Autowired PostRepository postRepository;
+    @Autowired UserRepository userRepository;
+    @Autowired PasswordEncoder passwordEncoder;
+    @Autowired JwtTokenProvider jwtTokenProvider;
+
+    User alice;
+    User bob;
+    String aliceToken;
+    String bobToken;
+
+    @BeforeEach
+    void setUp() {
+        postRepository.deleteAll();
+        userRepository.deleteAll();
+        alice = userRepository.save(new User("alice", passwordEncoder.encode("pw12345")));
+        bob = userRepository.save(new User("bob", passwordEncoder.encode("pw12345")));
+        aliceToken = "Bearer " + jwtTokenProvider.generateToken("alice");
+        bobToken = "Bearer " + jwtTokenProvider.generateToken("bob");
+    }
+
+    @AfterEach
+    void tearDown() {
+        postRepository.deleteAll();
+        userRepository.deleteAll();
+    }
+
+    // -------- Happy path --------
+
+    @Test
+    void 단건조회_존재하는_id면_200과_필드_일치() throws Exception {
+        Post saved = postRepository.save(new Post("hello", "world", alice));
+
+        mockMvc.perform(get("/api/posts/" + saved.getId()))
+                .andExpect(status().isOk())
+                .andExpect(jsonPath("$.id").value(saved.getId()))
+                .andExpect(jsonPath("$.title").value("hello"))
+                .andExpect(jsonPath("$.content").value("world"))
+                .andExpect(jsonPath("$.authorUsername").value("alice"))
+                .andExpect(jsonPath("$.createdAt").exists())
+                .andExpect(jsonPath("$.updatedAt").exists());
+    }
+
+    @Test
+    void 단건조회는_인증없이_접근_가능하다() throws Exception {
+        Post saved = postRepository.save(new Post("hello", "world", alice));
+        mockMvc.perform(get("/api/posts/" + saved.getId()))
+                .andExpect(status().isOk());
+    }
+
+    @Test
+    void 작성_인증된_사용자면_201과_authorUsername_일치() throws Exception {
+        mockMvc.perform(post("/api/posts")
+                        .header("Authorization", aliceToken)
+                        .contentType(MediaType.APPLICATION_JSON)
+                        .content("{\"title\":\"첫 글\",\"content\":\"본문\"}"))
+                .andExpect(status().isCreated())
+                .andExpect(jsonPath("$.id").isNumber())
+                .andExpect(jsonPath("$.title").value("첫 글"))
+                .andExpect(jsonPath("$.content").value("본문"))
+                .andExpect(jsonPath("$.authorUsername").value("alice"))
+                .andExpect(jsonPath("$.createdAt").exists())
+                .andExpect(jsonPath("$.updatedAt").exists());
+    }
+
+    @Test
+    void 수정_본인이면_200과_변경된_필드가_반영된다() throws Exception {
+        Post saved = postRepository.save(new Post("old", "old-body", alice));
+
+        mockMvc.perform(put("/api/posts/" + saved.getId())
+                        .header("Authorization", aliceToken)
+                        .contentType(MediaType.APPLICATION_JSON)
+                        .content("{\"title\":\"new\",\"content\":\"new-body\"}"))
+                .andExpect(status().isOk())
+                .andExpect(jsonPath("$.id").value(saved.getId()))
+                .andExpect(jsonPath("$.title").value("new"))
+                .andExpect(jsonPath("$.content").value("new-body"))
+                .andExpect(jsonPath("$.authorUsername").value("alice"));
+
+        Post reloaded = postRepository.findById(saved.getId()).orElseThrow();
+        assertThat(reloaded.getTitle()).isEqualTo("new");
+        assertThat(reloaded.getContent()).isEqualTo("new-body");
+    }
+
+    @Test
+    void 삭제_본인이면_204이고_다시_조회하면_404() throws Exception {
+        Post saved = postRepository.save(new Post("t", "c", alice));
+
+        mockMvc.perform(delete("/api/posts/" + saved.getId())
+                        .header("Authorization", aliceToken))
+                .andExpect(status().isNoContent());
+
+        mockMvc.perform(get("/api/posts/" + saved.getId()))
+                .andExpect(status().isNotFound());
+    }
+
+    // -------- Input validation (400) --------
+
+    @Test
+    void 작성_title이_null이면_400() throws Exception {
+        mockMvc.perform(post("/api/posts")
+                        .header("Authorization", aliceToken)
+                        .contentType(MediaType.APPLICATION_JSON)
+                        .content("{\"content\":\"본문\"}"))
+                .andExpect(status().isBadRequest())
+                .andExpect(jsonPath("$.message").value(containsString("title")));
+    }
+
+    @Test
+    void 작성_title이_빈문자열이면_400() throws Exception {
+        mockMvc.perform(post("/api/posts")
+                        .header("Authorization", aliceToken)
+                        .contentType(MediaType.APPLICATION_JSON)
+                        .content("{\"title\":\"\",\"content\":\"본문\"}"))
+                .andExpect(status().isBadRequest());
+    }
+
+    @Test
+    void 작성_title이_101자면_400() throws Exception {
+        String title = "a".repeat(101);
+        String body = "{\"title\":\"" + title + "\",\"content\":\"본문\"}";
+        mockMvc.perform(post("/api/posts")
+                        .header("Authorization", aliceToken)
+                        .contentType(MediaType.APPLICATION_JSON)
+                        .content(body))
+                .andExpect(status().isBadRequest());
+    }
+
+    @Test
+    void 작성_content가_null이면_400() throws Exception {
+        mockMvc.perform(post("/api/posts")
+                        .header("Authorization", aliceToken)
+                        .contentType(MediaType.APPLICATION_JSON)
+                        .content("{\"title\":\"제목\"}"))
+                .andExpect(status().isBadRequest())
+                .andExpect(jsonPath("$.message").value(containsString("content")));
+    }
+
+    @Test
+    void 작성_content가_빈문자열이면_400() throws Exception {
+        mockMvc.perform(post("/api/posts")
+                        .header("Authorization", aliceToken)
+                        .contentType(MediaType.APPLICATION_JSON)
+                        .content("{\"title\":\"제목\",\"content\":\"\"}"))
+                .andExpect(status().isBadRequest());
+    }
+
+    @Test
+    void 수정_title이_null이면_400() throws Exception {
+        Post saved = postRepository.save(new Post("t", "c", alice));
+        mockMvc.perform(put("/api/posts/" + saved.getId())
+                        .header("Authorization", aliceToken)
+                        .contentType(MediaType.APPLICATION_JSON)
+                        .content("{\"content\":\"본문\"}"))
+                .andExpect(status().isBadRequest());
+    }
+
+    @Test
+    void 수정_content가_빈문자열이면_400() throws Exception {
+        Post saved = postRepository.save(new Post("t", "c", alice));
+        mockMvc.perform(put("/api/posts/" + saved.getId())
+                        .header("Authorization", aliceToken)
+                        .contentType(MediaType.APPLICATION_JSON)
+                        .content("{\"title\":\"t\",\"content\":\"\"}"))
+                .andExpect(status().isBadRequest());
+    }
+
+    // -------- Authentication (401) --------
+
+    @Test
+    void 작성_토큰없으면_401() throws Exception {
+        mockMvc.perform(post("/api/posts")
+                        .contentType(MediaType.APPLICATION_JSON)
+                        .content("{\"title\":\"t\",\"content\":\"c\"}"))
+                .andExpect(status().isUnauthorized());
+    }
+
+    @Test
+    void 수정_토큰없으면_401() throws Exception {
+        Post saved = postRepository.save(new Post("t", "c", alice));
+        mockMvc.perform(put("/api/posts/" + saved.getId())
+                        .contentType(MediaType.APPLICATION_JSON)
+                        .content("{\"title\":\"t\",\"content\":\"c\"}"))
+                .andExpect(status().isUnauthorized());
+    }
+
+    @Test
+    void 삭제_토큰없으면_401() throws Exception {
+        Post saved = postRepository.save(new Post("t", "c", alice));
+        mockMvc.perform(delete("/api/posts/" + saved.getId()))
+                .andExpect(status().isUnauthorized());
+    }
+
+    // -------- Ownership (403) --------
+
+    @Test
+    void 타인의_글_수정_시도면_403이고_원본이_유지된다() throws Exception {
+        Post saved = postRepository.save(new Post("t", "c", alice));
+
+        mockMvc.perform(put("/api/posts/" + saved.getId())
+                        .header("Authorization", bobToken)
+                        .contentType(MediaType.APPLICATION_JSON)
+                        .content("{\"title\":\"hacked\",\"content\":\"x\"}"))
+                .andExpect(status().isForbidden());
+
+        Post reloaded = postRepository.findById(saved.getId()).orElseThrow();
+        assertThat(reloaded.getTitle()).isEqualTo("t");
+        assertThat(reloaded.getContent()).isEqualTo("c");
+    }
+
+    @Test
+    void 타인의_글_삭제_시도면_403이고_원본이_남아있다() throws Exception {
+        Post saved = postRepository.save(new Post("t", "c", alice));
+
+        mockMvc.perform(delete("/api/posts/" + saved.getId())
+                        .header("Authorization", bobToken))
+                .andExpect(status().isForbidden());
+
+        assertThat(postRepository.findById(saved.getId())).isPresent();
+    }
+
+    // -------- Resource state (404) --------
+
+    @Test
+    void 없는_id_단건조회면_404() throws Exception {
+        mockMvc.perform(get("/api/posts/9999"))
+                .andExpect(status().isNotFound())
+                .andExpect(jsonPath("$.status").value(404));
+    }
+
+    @Test
+    void 없는_id_수정이면_404() throws Exception {
+        mockMvc.perform(put("/api/posts/9999")
+                        .header("Authorization", aliceToken)
+                        .contentType(MediaType.APPLICATION_JSON)
+                        .content("{\"title\":\"t\",\"content\":\"c\"}"))
+                .andExpect(status().isNotFound());
+    }
+
+    @Test
+    void 없는_id_삭제면_404() throws Exception {
+        mockMvc.perform(delete("/api/posts/9999")
+                        .header("Authorization", aliceToken))
+                .andExpect(status().isNotFound());
+    }
+
+    @Test
+    void 이미_삭제된_글_재삭제면_404() throws Exception {
+        Post saved = postRepository.save(new Post("t", "c", alice));
+
+        mockMvc.perform(delete("/api/posts/" + saved.getId())
+                        .header("Authorization", aliceToken))
+                .andExpect(status().isNoContent());
+
+        mockMvc.perform(delete("/api/posts/" + saved.getId())
+                        .header("Authorization", aliceToken))
+                .andExpect(status().isNotFound());
+    }
+}

--- a/src/test/java/com/example/board/post/PostListControllerTest.java
+++ b/src/test/java/com/example/board/post/PostListControllerTest.java
@@ -1,0 +1,160 @@
+package com.example.board.post;
+
+import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.get;
+import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.jsonPath;
+import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.status;
+
+import com.example.board.user.User;
+import com.example.board.user.UserRepository;
+import org.junit.jupiter.api.AfterEach;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.boot.test.autoconfigure.web.servlet.AutoConfigureMockMvc;
+import org.springframework.boot.test.context.SpringBootTest;
+import org.springframework.security.crypto.password.PasswordEncoder;
+import org.springframework.test.context.ActiveProfiles;
+import org.springframework.test.web.servlet.MockMvc;
+
+@SpringBootTest
+@AutoConfigureMockMvc
+@ActiveProfiles("test")
+class PostListControllerTest {
+
+    @Autowired
+    MockMvc mockMvc;
+
+    @Autowired
+    PostRepository postRepository;
+
+    @Autowired
+    UserRepository userRepository;
+
+    @Autowired
+    PasswordEncoder passwordEncoder;
+
+    User alice;
+
+    @BeforeEach
+    void setUp() {
+        postRepository.deleteAll();
+        userRepository.deleteAll();
+        alice = userRepository.save(new User("alice", passwordEncoder.encode("pw12345")));
+    }
+
+    @AfterEach
+    void tearDown() {
+        postRepository.deleteAll();
+        userRepository.deleteAll();
+    }
+
+    @Test
+    void GET_목록은_인증없이_200이며_content는_배열이다() throws Exception {
+        mockMvc.perform(get("/api/posts"))
+                .andExpect(status().isOk())
+                .andExpect(jsonPath("$.content").isArray())
+                .andExpect(jsonPath("$.page").value(0))
+                .andExpect(jsonPath("$.size").value(10));
+    }
+
+    @Test
+    void 빈_목록이면_content는_빈배열이고_totalElements_0_totalPages_0이다() throws Exception {
+        mockMvc.perform(get("/api/posts"))
+                .andExpect(status().isOk())
+                .andExpect(jsonPath("$.content").isEmpty())
+                .andExpect(jsonPath("$.totalElements").value(0))
+                .andExpect(jsonPath("$.totalPages").value(0));
+    }
+
+    @Test
+    void 여러_글을_저장하면_최신순으로_정렬된다() throws Exception {
+        postRepository.save(new Post("old", "first", alice));
+        Thread.sleep(10);
+        postRepository.save(new Post("mid", "second", alice));
+        Thread.sleep(10);
+        Post latest = postRepository.save(new Post("new", "third", alice));
+
+        mockMvc.perform(get("/api/posts"))
+                .andExpect(status().isOk())
+                .andExpect(jsonPath("$.totalElements").value(3))
+                .andExpect(jsonPath("$.content[0].id").value(latest.getId()))
+                .andExpect(jsonPath("$.content[0].title").value("new"));
+    }
+
+    @Test
+    void 파라미터_없이_호출하면_page0_size10으로_동작한다() throws Exception {
+        for (int i = 0; i < 15; i++) {
+            postRepository.save(new Post("t" + i, "c" + i, alice));
+        }
+
+        mockMvc.perform(get("/api/posts"))
+                .andExpect(status().isOk())
+                .andExpect(jsonPath("$.page").value(0))
+                .andExpect(jsonPath("$.size").value(10))
+                .andExpect(jsonPath("$.totalElements").value(15))
+                .andExpect(jsonPath("$.totalPages").value(2))
+                .andExpect(jsonPath("$.content.length()").value(10));
+    }
+
+    @Test
+    void page1_size5로_조회하면_두번째_페이지가_5건_반환된다() throws Exception {
+        for (int i = 0; i < 15; i++) {
+            postRepository.save(new Post("t" + i, "c" + i, alice));
+        }
+
+        mockMvc.perform(get("/api/posts").param("page", "1").param("size", "5"))
+                .andExpect(status().isOk())
+                .andExpect(jsonPath("$.page").value(1))
+                .andExpect(jsonPath("$.size").value(5))
+                .andExpect(jsonPath("$.totalElements").value(15))
+                .andExpect(jsonPath("$.totalPages").value(3))
+                .andExpect(jsonPath("$.content.length()").value(5));
+    }
+
+    @Test
+    void 페이지_범위_밖이면_빈_content와_올바른_totalPages를_반환한다() throws Exception {
+        for (int i = 0; i < 3; i++) {
+            postRepository.save(new Post("t" + i, "c" + i, alice));
+        }
+
+        mockMvc.perform(get("/api/posts").param("page", "5").param("size", "10"))
+                .andExpect(status().isOk())
+                .andExpect(jsonPath("$.content").isEmpty())
+                .andExpect(jsonPath("$.totalElements").value(3))
+                .andExpect(jsonPath("$.totalPages").value(1));
+    }
+
+    @Test
+    void size가_0이면_400을_반환한다() throws Exception {
+        mockMvc.perform(get("/api/posts").param("size", "0"))
+                .andExpect(status().isBadRequest())
+                .andExpect(jsonPath("$.status").value(400));
+    }
+
+    @Test
+    void size가_음수면_400을_반환한다() throws Exception {
+        mockMvc.perform(get("/api/posts").param("size", "-1"))
+                .andExpect(status().isBadRequest());
+    }
+
+    @Test
+    void page가_음수면_400을_반환한다() throws Exception {
+        mockMvc.perform(get("/api/posts").param("page", "-1"))
+                .andExpect(status().isBadRequest())
+                .andExpect(jsonPath("$.status").value(400));
+    }
+
+    @Test
+    void 목록_응답_항목은_id_title_content_authorUsername_createdAt_updatedAt을_포함한다() throws Exception {
+        postRepository.save(new Post("hello", "world", alice));
+
+        mockMvc.perform(get("/api/posts"))
+                .andExpect(status().isOk())
+                .andExpect(jsonPath("$.content[0].id").isNumber())
+                .andExpect(jsonPath("$.content[0].title").value("hello"))
+                .andExpect(jsonPath("$.content[0].content").value("world"))
+                .andExpect(jsonPath("$.content[0].authorUsername").value("alice"))
+                .andExpect(jsonPath("$.content[0].createdAt").exists())
+                .andExpect(jsonPath("$.content[0].updatedAt").exists());
+    }
+}


### PR DESCRIPTION
Closes #4

## Summary
- 게시글 CRUD 5개 엔드포인트: 목록·단건 조회(공개), 작성·수정·삭제(인증). 수정·삭제는 작성자 본인만 허용(403).
- `Post` 엔티티 + `PostRepository`(`@EntityGraph`로 author eager 로드하여 N+1 방지), `PostService`에 본인 확인·404 예외 집중.
- `GlobalExceptionHandler`에 `ResponseStatusException → ErrorResponse` 매핑 추가, `SecurityConfig`에 GET `/api/posts`·`/api/posts/*` permitAll.

## TDD 증적
- 커밋 쌍: `test: #4 ... (RED)` → `feat: #4 ... (GREEN)`
- RED에서 선제 설계한 edge case (총 30개 테스트):
  - **입력 검증(400)**: title null/빈/101자, content null/빈, 수정 요청 동일
  - **인증(401)**: 작성·수정·삭제 토큰 부재
  - **권한(403)**: 타인 수정·삭제 시도 시 원본 유지까지 assert
  - **리소스 상태(404)**: 미존재 id 조회/수정/삭제, 이미 삭제된 글 재삭제
  - **페이지네이션 경계**: 빈 목록, 범위 밖 page, size=0, page<0, size=5&page=1, default page=0&size=10
  - **응답 포맷**: id·title·content·authorUsername·createdAt·updatedAt 필드 일치

## Test plan
- [x] `./gradlew clean build` 로컬 초록불 (84 tests PASS, INSTRUCTION 커버리지 **97.65%**)
- [x] `./gradlew jacocoTestCoverageVerification` 95% 게이트 통과
- [x] 수동 시연: `bootRun` + curl로 18개 시나리오 검증 (signup → login → POST/GET/PUT/DELETE /api/posts + 권한·404·페이지네이션 400)
- [x] CI 초록불 — `Test + Coverage` (1m18s), `Build (no tests)` (31s) 두 잡 [run 24768372177](https://github.com/marcosdeseul/dihisoft-claude-session/actions/runs/24768372177)

## 파일 변경 요약 (총 10개)

| # | 파일 | 구분 | 비고 |
|---|---|---|---|
| 1 | `post/Post.java` | 신규 | 엔티티 (`BaseEntity` 상속, `author @ManyToOne`, `update()`·`isOwnedBy()`) |
| 2 | `post/PostRepository.java` | 신규 | `findAllByOrderByCreatedAtDesc`·`findById` 에 `@EntityGraph("author")` |
| 3 | `post/PostService.java` | 신규 | CRUD + `assertOwnedBy` + `ResponseStatusException(404)` |
| 4 | `post/PostController.java` | 신규 | 5개 엔드포인트, page/size 수동 검증(400) |
| 5 | `post/PostWriteRequest.java` | 신규 | `Create`·`Update` 내포 record (동일 스펙 → 한 파일로 응집) |
| 6 | `post/PostResponse.java` | 신규 | `from(Post)` + 내포 `PageResponse<T>` |
| 7 | `config/SecurityConfig.java` | 수정 | GET `/api/posts`·`/api/posts/*` permitAll 추가 |
| 8 | `common/GlobalExceptionHandler.java` | 수정 | `ResponseStatusException → ErrorResponse` 핸들러 추가 |
| 9 | `test/post/PostCrudControllerTest.java` | 신규 | happy + 인증 + 권한 + 검증 + 404 (289줄, 20개 케이스) |
| 10 | `test/post/PostListControllerTest.java` | 신규 | 목록 + 페이지네이션 경계 (160줄, 10개 케이스) |

모든 신규 파일 300줄 미만, 10개 한도 충족 (CLAUDE.md §작업 단위 제약).

## 주의
- **N+1 방지 설계**: `@ManyToOne(fetch=LAZY)` + `@EntityGraph(attributePaths="author")` 로 `findById`·`findAll`에서 author를 한 번에 fetch. `open-in-view=false` 환경에서 컨트롤러가 `PostResponse.from(post)` 시 `author.getUsername()` 을 호출해도 LazyInit 발생 안 함.
- **404 설계**: 프로젝트 전반에서 재사용 가능하도록 신규 예외 클래스 대신 Spring 표준 `ResponseStatusException` 사용. `GlobalExceptionHandler`가 이를 받아 기존 `ErrorResponse` 포맷으로 정규화.
- **선행 이슈**: #3 (2.0 인증) 머지 완료 전제 — `JwtAuthenticationFilter`·`BaseEntity`·`GlobalExceptionHandler` 등 인프라 그대로 재사용.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
