### PR TITLE
ci: Java 포매터(Spotless) + 린터(Checkstyle) + 세션 종료 포매팅 훅 도입

### DIFF
--- a/.claude/settings.json
+++ b/.claude/settings.json
@@ -1,0 +1,17 @@
+{
+  "$schema": "https://json.schemastore.org/claude-code-settings.json",
+  "hooks": {
+    "SessionEnd": [
+      {
+        "matcher": "",
+        "hooks": [
+          {
+            "type": "command",
+            "command": "cd \"$CLAUDE_PROJECT_DIR\" && ./gradlew spotlessApply -q --console=plain || true",
+            "timeout": 120
+          }
+        ]
+      }
+    ]
+  }
+}

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -6,8 +6,35 @@ on:
     branches: [main]
 
 jobs:
+  lint:
+    name: Lint (Spotless + Checkstyle)
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+
+      - name: Set up JDK 21
+        uses: actions/setup-java@v4
+        with:
+          distribution: temurin
+          java-version: "21"
+
+      - name: Setup Gradle
+        uses: gradle/actions/setup-gradle@v4
+
+      - name: Run lint (spotlessCheck + checkstyle)
+        run: ./gradlew lint --no-daemon
+
+      - name: Upload Checkstyle report on failure
+        if: failure()
+        uses: actions/upload-artifact@v4
+        with:
+          name: checkstyle-report
+          path: build/reports/checkstyle
+          if-no-files-found: ignore
+
   test:
     name: Test + Coverage
+    needs: lint
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v4
@@ -57,6 +84,7 @@ jobs:
 
   build:
     name: Build (no tests)
+    needs: lint
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v4

--- a/build.gradle.kts
+++ b/build.gradle.kts
@@ -1,8 +1,10 @@
 plugins {
     java
     jacoco
+    checkstyle
     id("org.springframework.boot") version "3.3.5"
     id("io.spring.dependency-management") version "1.1.6"
+    id("com.diffplug.spotless") version "6.25.0"
 }
 
 group = "com.example"
@@ -69,4 +71,34 @@ tasks.jacocoTestCoverageVerification {
             }
         }
     }
+}
+
+spotless {
+    java {
+        target("src/**/*.java")
+        googleJavaFormat("1.22.0")
+        removeUnusedImports()
+        trimTrailingWhitespace()
+        endWithNewline()
+    }
+    kotlinGradle {
+        target("*.gradle.kts")
+        ktlint()
+    }
+}
+
+checkstyle {
+    toolVersion = "10.17.0"
+    configFile = rootProject.file("config/checkstyle/checkstyle.xml")
+    configProperties = mapOf(
+        "suppressionFile" to rootProject.file("config/checkstyle/suppressions.xml").absolutePath,
+    )
+    isIgnoreFailures = false
+    maxWarnings = 0
+}
+
+tasks.register("lint") {
+    group = "verification"
+    description = "Run all static checks (spotlessCheck + checkstyle)."
+    dependsOn("spotlessCheck", "checkstyleMain", "checkstyleTest")
 }

--- a/config/checkstyle/checkstyle.xml
+++ b/config/checkstyle/checkstyle.xml
@@ -1,0 +1,80 @@
+<?xml version="1.0"?>
+<!DOCTYPE module PUBLIC
+        "-//Checkstyle//DTD Checkstyle Configuration 1.3//EN"
+        "https://checkstyle.org/dtds/configuration_1_3.dtd">
+
+<!--
+    Semantic-only lint rules.
+    Layout/whitespace/import order are handled by Spotless + google-java-format,
+    so those categories are intentionally omitted here to avoid conflicts.
+-->
+<module name="Checker">
+    <property name="severity" value="error"/>
+    <property name="fileExtensions" value="java"/>
+
+    <module name="SuppressionFilter">
+        <property name="file" value="${suppressionFile}"/>
+        <property name="optional" value="false"/>
+    </module>
+
+    <module name="FileTabCharacter">
+        <property name="eachLine" value="true"/>
+    </module>
+
+    <module name="LineLength">
+        <property name="max" value="140"/>
+        <property name="ignorePattern" value="^package .*|^import .*|a href|href|http://|https://|ftp://"/>
+    </module>
+
+    <module name="TreeWalker">
+        <module name="SuppressionCommentFilter"/>
+
+        <!-- Imports -->
+        <module name="AvoidStarImport"/>
+        <module name="RedundantImport"/>
+        <module name="UnusedImports">
+            <property name="processJavadoc" value="true"/>
+        </module>
+
+        <!-- Blocks / braces -->
+        <module name="EmptyBlock">
+            <property name="option" value="text"/>
+            <property name="tokens"
+                      value="LITERAL_TRY, LITERAL_FINALLY, LITERAL_IF, LITERAL_ELSE,
+                             LITERAL_FOR, LITERAL_WHILE, LITERAL_DO,
+                             LITERAL_SWITCH, LITERAL_SYNCHRONIZED, LITERAL_CASE,
+                             LITERAL_DEFAULT, STATIC_INIT, INSTANCE_INIT"/>
+        </module>
+        <module name="NeedBraces"/>
+
+        <!-- Coding practices -->
+        <module name="EqualsHashCode"/>
+        <module name="EqualsAvoidNull"/>
+        <module name="MissingOverride"/>
+        <module name="SimplifyBooleanExpression"/>
+        <module name="SimplifyBooleanReturn"/>
+        <module name="StringLiteralEquality"/>
+        <module name="OneStatementPerLine"/>
+        <module name="MultipleVariableDeclarations"/>
+        <module name="FallThrough"/>
+        <module name="DefaultComesLast"/>
+
+        <!-- Magic numbers: common literals and annotation values excluded -->
+        <module name="MagicNumber">
+            <property name="ignoreNumbers" value="-1, 0, 1, 2, 3, 100, 1000"/>
+            <property name="ignoreHashCodeMethod" value="true"/>
+            <property name="ignoreAnnotation" value="true"/>
+            <property name="ignoreFieldDeclaration" value="true"/>
+        </module>
+
+        <!-- Class design -->
+        <module name="FinalClass"/>
+        <module name="HideUtilityClassConstructor"/>
+        <module name="ModifierOrder"/>
+        <module name="RedundantModifier"/>
+
+        <!-- Misc -->
+        <module name="UpperEll"/>
+        <module name="ArrayTypeStyle"/>
+    </module>
+</module>

--- a/config/checkstyle/suppressions.xml
+++ b/config/checkstyle/suppressions.xml
@@ -1,0 +1,14 @@
+<?xml version="1.0"?>
+<!DOCTYPE suppressions PUBLIC
+        "-//Checkstyle//DTD SuppressionFilter Configuration 1.2//EN"
+        "https://checkstyle.org/dtds/suppressions_1_2.dtd">
+
+<suppressions>
+    <!-- Tests: relax magic-number / utility-class-ctor rules -->
+    <suppress files="[\\/]src[\\/]test[\\/]" checks="MagicNumber"/>
+    <suppress files="[\\/]src[\\/]test[\\/]" checks="HideUtilityClassConstructor"/>
+
+    <!-- Generated sources (MapStruct, Querydsl, build output) -->
+    <suppress files="[\\/]build[\\/]generated[\\/]" checks=".*"/>
+    <suppress files="[\\/]generated[\\/]" checks=".*"/>
+</suppressions>


### PR DESCRIPTION
## Summary
- Spring Boot(Java 21) 프로젝트에 포매터(Spotless + google-java-format) · 린터(Checkstyle) 도입으로 스타일 diff 노이즈 차단
- CI에 `lint` 잡 신설, `test`/`build` 잡이 `needs: lint`로 선행 게이트
- Claude Code `SessionEnd` 훅으로 세션 종료 시 `./gradlew spotlessApply` 자동 실행 → 다음 커밋 diff 자동 수렴

## 설계 포인트
- **Spotless vs Checkstyle 책임 분리**: 공백/줄바꿈/임포트 정렬 = Spotless(google-java-format), 의미론적 린트(`UnusedImports`, `EqualsHashCode`, `MagicNumber`, `NeedBraces` 등) = Checkstyle. 두 툴 간 룰 충돌 제거.
- **Checkstyle `maxWarnings = 0`**: 경고도 빌드 실패로 승격. 초기 튜닝이 빡셀 경우 `suppressions.xml`에 한시 예외 후 후속 이슈로 해제.
- **`SessionEnd` 훅 설계**:
  - `matcher: ""`로 모든 종료 reason(clear/logout/prompt_input_exit/other) 포괄
  - `|| true`로 best-effort 실행(세션 종료 UX를 훅 실패가 막지 않게)
  - **훅은 커밋/푸시하지 않는다** — 리버시블하지 않은 동작 금지

## Test plan
- [ ] CI `lint` 잡 초록불 (PR 생성 직후 확인)
  - 주의: 기존 Java 소스에 포매팅/린트 위반이 있으면 이 PR의 `lint` 잡이 실패할 수 있음. 그 경우 `chore(format): 초기 spotlessApply 일괄 적용` 별도 커밋으로 수정 → 재 push
- [ ] CI `test` 잡 초록불 (JaCoCo 95% INSTRUCTION 유지 — 본 PR은 프로덕션 코드 변경 없음)
- [ ] CI `build` 잡 초록불
- [ ] 로컬 훅 검증: Java 파일 하나를 고의로 비정상 포맷으로 저장 → `/clear` 또는 세션 종료 → 다음 세션에서 `git diff`로 포맷 복원 확인

> **로컬 `./gradlew clean build` 미실행**: 이 워크트리 환경에 JDK가 없어 로컬 검증을 스킵함. 설정/YAML/XML은 모두 파서 레벨로 문법 검증(`python3 -m json.tool`, `xml.etree.ElementTree`, `PyYAML`) 통과. 1차 검증은 CI에 의존.

## 파일 변경 요약 (5개, CLAUDE.md 10개 한도 내)
| # | 파일 | 구분 | 비고 |
|---|---|---|---|
| 1 | `build.gradle.kts` | 수정 | Spotless + Checkstyle 플러그인 및 `lint` 태스크 (+32줄) |
| 2 | `config/checkstyle/checkstyle.xml` | 신규 | 의미론적 린트 규칙 (80줄) |
| 3 | `config/checkstyle/suppressions.xml` | 신규 | 테스트·생성 소스 예외 (14줄) |
| 4 | `.github/workflows/ci.yml` | 수정 | `lint` 잡 신설, `test`/`build`에 `needs: lint` (+28줄) |
| 5 | `.claude/settings.json` | 신규 | `SessionEnd` 훅 (17줄) |

## 주의
- TDD 원칙 예외 — CLAUDE.md 예외 조항(설정/빌드 파일)에 해당. 프로덕션 코드 로직 변경 없음.
- 기존 소스의 포매팅/린트 일괄 수정은 **이번 PR 범위 밖**. 본 PR은 규칙·훅 도입만, 대량 재포맷은 별도 `chore(format): ...` PR로 분리 권장.
- `.claude/settings.json`은 팀 공유(레포 커밋). 개인 오버라이드는 `.claude/settings.local.json`(gitignore)로.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
