### PR TITLE
feat: #30 React(Vite+TS) 스캐폴딩 + Gradle 통합 + SPA 폴백

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -45,3 +45,10 @@ bin/
 
 # Playwright MCP / manual-test skill artifacts
 .playwright-mcp/
+
+# Agent handoff scratch (plan files for other agents, etc.)
+temp/
+
+# Frontend
+frontend/node_modules/
+frontend/dist/

--- a/build.gradle.kts
+++ b/build.gradle.kts
@@ -2,6 +2,7 @@ plugins {
     java
     jacoco
     checkstyle
+    id("com.github.node-gradle.node") version "7.1.0"
     id("org.springframework.boot") version "3.3.5"
     id("io.spring.dependency-management") version "1.1.6"
     id("com.diffplug.spotless") version "6.25.0"
@@ -18,6 +19,12 @@ java {
 
 repositories {
     mavenCentral()
+}
+
+node {
+    version.set("20.11.1")
+    download.set(true)
+    nodeProjectDir.set(file("frontend"))
 }
 
 dependencies {
@@ -73,6 +80,38 @@ tasks.jacocoTestCoverageVerification {
     }
 }
 
+val buildFrontend by tasks.registering(com.github.gradle.node.npm.task.NpmTask::class) {
+    dependsOn(tasks.npmInstall)
+    args.set(listOf("run", "build"))
+    inputs.dir("frontend/src")
+    inputs.file("frontend/package.json")
+    inputs.file("frontend/vite.config.ts")
+    inputs.file("frontend/tsconfig.json")
+    inputs.file("frontend/index.html")
+    outputs.dir("frontend/dist")
+}
+
+tasks.processResources {
+    dependsOn(buildFrontend)
+    from("frontend/dist") {
+        into("static")
+    }
+}
+
+val verifyFrontendBundle by tasks.registering {
+    dependsOn(tasks.processResources)
+    doLast {
+        val indexHtml = layout.buildDirectory.file("resources/main/static/index.html").get().asFile
+        require(indexHtml.exists()) {
+            "Frontend bundle missing: ${indexHtml.absolutePath}"
+        }
+    }
+}
+
+tasks.check {
+    dependsOn(verifyFrontendBundle)
+}
+
 spotless {
     java {
         target("src/**/*.java")
@@ -90,9 +129,10 @@ spotless {
 checkstyle {
     toolVersion = "10.17.0"
     configFile = rootProject.file("config/checkstyle/checkstyle.xml")
-    configProperties = mapOf(
-        "suppressionFile" to rootProject.file("config/checkstyle/suppressions.xml").absolutePath,
-    )
+    configProperties =
+        mapOf(
+            "suppressionFile" to rootProject.file("config/checkstyle/suppressions.xml").absolutePath,
+        )
     isIgnoreFailures = false
     maxWarnings = 0
 }

--- a/config/checkstyle/suppressions.xml
+++ b/config/checkstyle/suppressions.xml
@@ -8,6 +8,9 @@
     <suppress files="[\\/]src[\\/]test[\\/]" checks="MagicNumber"/>
     <suppress files="[\\/]src[\\/]test[\\/]" checks="HideUtilityClassConstructor"/>
 
+    <!-- Spring Boot main class: @SpringBootApplication entrypoint, not a utility class -->
+    <suppress files="BoardApplication\.java" checks="HideUtilityClassConstructor"/>
+
     <!-- Generated sources (MapStruct, Querydsl, build output) -->
     <suppress files="[\\/]build[\\/]generated[\\/]" checks=".*"/>
     <suppress files="[\\/]generated[\\/]" checks=".*"/>

--- a/frontend/index.html
+++ b/frontend/index.html
@@ -1,0 +1,12 @@
+<!doctype html>
+<html lang="ko">
+  <head>
+    <meta charset="UTF-8" />
+    <meta name="viewport" content="width=device-width, initial-scale=1.0" />
+    <title>Board</title>
+  </head>
+  <body>
+    <div id="root"></div>
+    <script type="module" src="/src/main.tsx"></script>
+  </body>
+</html>

--- a/frontend/package-lock.json
+++ b/frontend/package-lock.json
@@ -1,0 +1,1501 @@
+{
+  "name": "frontend",
+  "lockfileVersion": 3,
+  "requires": true,
+  "packages": {
+    "": {
+      "dependencies": {
+        "@vitejs/plugin-react": "4.3.4",
+        "react": "18.3.1",
+        "react-dom": "18.3.1",
+        "typescript": "5.6.3",
+        "vite": "5.4.21"
+      },
+      "devDependencies": {
+        "@types/react": "18.3.12",
+        "@types/react-dom": "18.3.1"
+      }
+    },
+    "node_modules/@babel/code-frame": {
+      "version": "7.29.0",
+      "resolved": "https://registry.npmjs.org/@babel/code-frame/-/code-frame-7.29.0.tgz",
+      "integrity": "sha512-9NhCeYjq9+3uxgdtp20LSiJXJvN0FeCtNGpJxuMFZ1Kv3cWUNb6DOhJwUvcVCzKGR66cw4njwM6hrJLqgOwbcw==",
+      "dependencies": {
+        "@babel/helper-validator-identifier": "^7.28.5",
+        "js-tokens": "^4.0.0",
+        "picocolors": "^1.1.1"
+      },
+      "engines": {
+        "node": ">=6.9.0"
+      }
+    },
+    "node_modules/@babel/compat-data": {
+      "version": "7.29.0",
+      "resolved": "https://registry.npmjs.org/@babel/compat-data/-/compat-data-7.29.0.tgz",
+      "integrity": "sha512-T1NCJqT/j9+cn8fvkt7jtwbLBfLC/1y1c7NtCeXFRgzGTsafi68MRv8yzkYSapBnFA6L3U2VSc02ciDzoAJhJg==",
+      "engines": {
+        "node": ">=6.9.0"
+      }
+    },
+    "node_modules/@babel/core": {
+      "version": "7.29.0",
+      "resolved": "https://registry.npmjs.org/@babel/core/-/core-7.29.0.tgz",
+      "integrity": "sha512-CGOfOJqWjg2qW/Mb6zNsDm+u5vFQ8DxXfbM09z69p5Z6+mE1ikP2jUXw+j42Pf1XTYED2Rni5f95npYeuwMDQA==",
+      "dependencies": {
+        "@babel/code-frame": "^7.29.0",
+        "@babel/generator": "^7.29.0",
+        "@babel/helper-compilation-targets": "^7.28.6",
+        "@babel/helper-module-transforms": "^7.28.6",
+        "@babel/helpers": "^7.28.6",
+        "@babel/parser": "^7.29.0",
+        "@babel/template": "^7.28.6",
+        "@babel/traverse": "^7.29.0",
+        "@babel/types": "^7.29.0",
+        "@jridgewell/remapping": "^2.3.5",
+        "convert-source-map": "^2.0.0",
+        "debug": "^4.1.0",
+        "gensync": "^1.0.0-beta.2",
+        "json5": "^2.2.3",
+        "semver": "^6.3.1"
+      },
+      "engines": {
+        "node": ">=6.9.0"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/babel"
+      }
+    },
+    "node_modules/@babel/generator": {
+      "version": "7.29.1",
+      "resolved": "https://registry.npmjs.org/@babel/generator/-/generator-7.29.1.tgz",
+      "integrity": "sha512-qsaF+9Qcm2Qv8SRIMMscAvG4O3lJ0F1GuMo5HR/Bp02LopNgnZBC/EkbevHFeGs4ls/oPz9v+Bsmzbkbe+0dUw==",
+      "dependencies": {
+        "@babel/parser": "^7.29.0",
+        "@babel/types": "^7.29.0",
+        "@jridgewell/gen-mapping": "^0.3.12",
+        "@jridgewell/trace-mapping": "^0.3.28",
+        "jsesc": "^3.0.2"
+      },
+      "engines": {
+        "node": ">=6.9.0"
+      }
+    },
+    "node_modules/@babel/helper-compilation-targets": {
+      "version": "7.28.6",
+      "resolved": "https://registry.npmjs.org/@babel/helper-compilation-targets/-/helper-compilation-targets-7.28.6.tgz",
+      "integrity": "sha512-JYtls3hqi15fcx5GaSNL7SCTJ2MNmjrkHXg4FSpOA/grxK8KwyZ5bubHsCq8FXCkua6xhuaaBit+3b7+VZRfcA==",
+      "dependencies": {
+        "@babel/compat-data": "^7.28.6",
+        "@babel/helper-validator-option": "^7.27.1",
+        "browserslist": "^4.24.0",
+        "lru-cache": "^5.1.1",
+        "semver": "^6.3.1"
+      },
+      "engines": {
+        "node": ">=6.9.0"
+      }
+    },
+    "node_modules/@babel/helper-globals": {
+      "version": "7.28.0",
+      "resolved": "https://registry.npmjs.org/@babel/helper-globals/-/helper-globals-7.28.0.tgz",
+      "integrity": "sha512-+W6cISkXFa1jXsDEdYA8HeevQT/FULhxzR99pxphltZcVaugps53THCeiWA8SguxxpSp3gKPiuYfSWopkLQ4hw==",
+      "engines": {
+        "node": ">=6.9.0"
+      }
+    },
+    "node_modules/@babel/helper-module-imports": {
+      "version": "7.28.6",
+      "resolved": "https://registry.npmjs.org/@babel/helper-module-imports/-/helper-module-imports-7.28.6.tgz",
+      "integrity": "sha512-l5XkZK7r7wa9LucGw9LwZyyCUscb4x37JWTPz7swwFE/0FMQAGpiWUZn8u9DzkSBWEcK25jmvubfpw2dnAMdbw==",
+      "dependencies": {
+        "@babel/traverse": "^7.28.6",
+        "@babel/types": "^7.28.6"
+      },
+      "engines": {
+        "node": ">=6.9.0"
+      }
+    },
+    "node_modules/@babel/helper-module-transforms": {
+      "version": "7.28.6",
+      "resolved": "https://registry.npmjs.org/@babel/helper-module-transforms/-/helper-module-transforms-7.28.6.tgz",
+      "integrity": "sha512-67oXFAYr2cDLDVGLXTEABjdBJZ6drElUSI7WKp70NrpyISso3plG9SAGEF6y7zbha/wOzUByWWTJvEDVNIUGcA==",
+      "dependencies": {
+        "@babel/helper-module-imports": "^7.28.6",
+        "@babel/helper-validator-identifier": "^7.28.5",
+        "@babel/traverse": "^7.28.6"
+      },
+      "engines": {
+        "node": ">=6.9.0"
+      },
+      "peerDependencies": {
+        "@babel/core": "^7.0.0"
+      }
+    },
+    "node_modules/@babel/helper-plugin-utils": {
+      "version": "7.28.6",
+      "resolved": "https://registry.npmjs.org/@babel/helper-plugin-utils/-/helper-plugin-utils-7.28.6.tgz",
+      "integrity": "sha512-S9gzZ/bz83GRysI7gAD4wPT/AI3uCnY+9xn+Mx/KPs2JwHJIz1W8PZkg2cqyt3RNOBM8ejcXhV6y8Og7ly/Dug==",
+      "engines": {
+        "node": ">=6.9.0"
+      }
+    },
+    "node_modules/@babel/helper-string-parser": {
+      "version": "7.27.1",
+      "resolved": "https://registry.npmjs.org/@babel/helper-string-parser/-/helper-string-parser-7.27.1.tgz",
+      "integrity": "sha512-qMlSxKbpRlAridDExk92nSobyDdpPijUq2DW6oDnUqd0iOGxmQjyqhMIihI9+zv4LPyZdRje2cavWPbCbWm3eA==",
+      "engines": {
+        "node": ">=6.9.0"
+      }
+    },
+    "node_modules/@babel/helper-validator-identifier": {
+      "version": "7.28.5",
+      "resolved": "https://registry.npmjs.org/@babel/helper-validator-identifier/-/helper-validator-identifier-7.28.5.tgz",
+      "integrity": "sha512-qSs4ifwzKJSV39ucNjsvc6WVHs6b7S03sOh2OcHF9UHfVPqWWALUsNUVzhSBiItjRZoLHx7nIarVjqKVusUZ1Q==",
+      "engines": {
+        "node": ">=6.9.0"
+      }
+    },
+    "node_modules/@babel/helper-validator-option": {
+      "version": "7.27.1",
+      "resolved": "https://registry.npmjs.org/@babel/helper-validator-option/-/helper-validator-option-7.27.1.tgz",
+      "integrity": "sha512-YvjJow9FxbhFFKDSuFnVCe2WxXk1zWc22fFePVNEaWJEu8IrZVlda6N0uHwzZrUM1il7NC9Mlp4MaJYbYd9JSg==",
+      "engines": {
+        "node": ">=6.9.0"
+      }
+    },
+    "node_modules/@babel/helpers": {
+      "version": "7.29.2",
+      "resolved": "https://registry.npmjs.org/@babel/helpers/-/helpers-7.29.2.tgz",
+      "integrity": "sha512-HoGuUs4sCZNezVEKdVcwqmZN8GoHirLUcLaYVNBK2J0DadGtdcqgr3BCbvH8+XUo4NGjNl3VOtSjEKNzqfFgKw==",
+      "dependencies": {
+        "@babel/template": "^7.28.6",
+        "@babel/types": "^7.29.0"
+      },
+      "engines": {
+        "node": ">=6.9.0"
+      }
+    },
+    "node_modules/@babel/parser": {
+      "version": "7.29.2",
+      "resolved": "https://registry.npmjs.org/@babel/parser/-/parser-7.29.2.tgz",
+      "integrity": "sha512-4GgRzy/+fsBa72/RZVJmGKPmZu9Byn8o4MoLpmNe1m8ZfYnz5emHLQz3U4gLud6Zwl0RZIcgiLD7Uq7ySFuDLA==",
+      "dependencies": {
+        "@babel/types": "^7.29.0"
+      },
+      "bin": {
+        "parser": "bin/babel-parser.js"
+      },
+      "engines": {
+        "node": ">=6.0.0"
+      }
+    },
+    "node_modules/@babel/plugin-transform-react-jsx-self": {
+      "version": "7.27.1",
+      "resolved": "https://registry.npmjs.org/@babel/plugin-transform-react-jsx-self/-/plugin-transform-react-jsx-self-7.27.1.tgz",
+      "integrity": "sha512-6UzkCs+ejGdZ5mFFC/OCUrv028ab2fp1znZmCZjAOBKiBK2jXD1O+BPSfX8X2qjJ75fZBMSnQn3Rq2mrBJK2mw==",
+      "dependencies": {
+        "@babel/helper-plugin-utils": "^7.27.1"
+      },
+      "engines": {
+        "node": ">=6.9.0"
+      },
+      "peerDependencies": {
+        "@babel/core": "^7.0.0-0"
+      }
+    },
+    "node_modules/@babel/plugin-transform-react-jsx-source": {
+      "version": "7.27.1",
+      "resolved": "https://registry.npmjs.org/@babel/plugin-transform-react-jsx-source/-/plugin-transform-react-jsx-source-7.27.1.tgz",
+      "integrity": "sha512-zbwoTsBruTeKB9hSq73ha66iFeJHuaFkUbwvqElnygoNbj/jHRsSeokowZFN3CZ64IvEqcmmkVe89OPXc7ldAw==",
+      "dependencies": {
+        "@babel/helper-plugin-utils": "^7.27.1"
+      },
+      "engines": {
+        "node": ">=6.9.0"
+      },
+      "peerDependencies": {
+        "@babel/core": "^7.0.0-0"
+      }
+    },
+    "node_modules/@babel/template": {
+      "version": "7.28.6",
+      "resolved": "https://registry.npmjs.org/@babel/template/-/template-7.28.6.tgz",
+      "integrity": "sha512-YA6Ma2KsCdGb+WC6UpBVFJGXL58MDA6oyONbjyF/+5sBgxY/dwkhLogbMT2GXXyU84/IhRw/2D1Os1B/giz+BQ==",
+      "dependencies": {
+        "@babel/code-frame": "^7.28.6",
+        "@babel/parser": "^7.28.6",
+        "@babel/types": "^7.28.6"
+      },
+      "engines": {
+        "node": ">=6.9.0"
+      }
+    },
+    "node_modules/@babel/traverse": {
+      "version": "7.29.0",
+      "resolved": "https://registry.npmjs.org/@babel/traverse/-/traverse-7.29.0.tgz",
+      "integrity": "sha512-4HPiQr0X7+waHfyXPZpWPfWL/J7dcN1mx9gL6WdQVMbPnF3+ZhSMs8tCxN7oHddJE9fhNE7+lxdnlyemKfJRuA==",
+      "dependencies": {
+        "@babel/code-frame": "^7.29.0",
+        "@babel/generator": "^7.29.0",
+        "@babel/helper-globals": "^7.28.0",
+        "@babel/parser": "^7.29.0",
+        "@babel/template": "^7.28.6",
+        "@babel/types": "^7.29.0",
+        "debug": "^4.3.1"
+      },
+      "engines": {
+        "node": ">=6.9.0"
+      }
+    },
+    "node_modules/@babel/types": {
+      "version": "7.29.0",
+      "resolved": "https://registry.npmjs.org/@babel/types/-/types-7.29.0.tgz",
+      "integrity": "sha512-LwdZHpScM4Qz8Xw2iKSzS+cfglZzJGvofQICy7W7v4caru4EaAmyUuO6BGrbyQ2mYV11W0U8j5mBhd14dd3B0A==",
+      "dependencies": {
+        "@babel/helper-string-parser": "^7.27.1",
+        "@babel/helper-validator-identifier": "^7.28.5"
+      },
+      "engines": {
+        "node": ">=6.9.0"
+      }
+    },
+    "node_modules/@esbuild/aix-ppc64": {
+      "version": "0.21.5",
+      "resolved": "https://registry.npmjs.org/@esbuild/aix-ppc64/-/aix-ppc64-0.21.5.tgz",
+      "integrity": "sha512-1SDgH6ZSPTlggy1yI6+Dbkiz8xzpHJEVAlF/AM1tHPLsf5STom9rwtjE4hKAF20FfXXNTFqEYXyJNWh1GiZedQ==",
+      "cpu": [
+        "ppc64"
+      ],
+      "optional": true,
+      "os": [
+        "aix"
+      ],
+      "engines": {
+        "node": ">=12"
+      }
+    },
+    "node_modules/@esbuild/android-arm": {
+      "version": "0.21.5",
+      "resolved": "https://registry.npmjs.org/@esbuild/android-arm/-/android-arm-0.21.5.tgz",
+      "integrity": "sha512-vCPvzSjpPHEi1siZdlvAlsPxXl7WbOVUBBAowWug4rJHb68Ox8KualB+1ocNvT5fjv6wpkX6o/iEpbDrf68zcg==",
+      "cpu": [
+        "arm"
+      ],
+      "optional": true,
+      "os": [
+        "android"
+      ],
+      "engines": {
+        "node": ">=12"
+      }
+    },
+    "node_modules/@esbuild/android-arm64": {
+      "version": "0.21.5",
+      "resolved": "https://registry.npmjs.org/@esbuild/android-arm64/-/android-arm64-0.21.5.tgz",
+      "integrity": "sha512-c0uX9VAUBQ7dTDCjq+wdyGLowMdtR/GoC2U5IYk/7D1H1JYC0qseD7+11iMP2mRLN9RcCMRcjC4YMclCzGwS/A==",
+      "cpu": [
+        "arm64"
+      ],
+      "optional": true,
+      "os": [
+        "android"
+      ],
+      "engines": {
+        "node": ">=12"
+      }
+    },
+    "node_modules/@esbuild/android-x64": {
+      "version": "0.21.5",
+      "resolved": "https://registry.npmjs.org/@esbuild/android-x64/-/android-x64-0.21.5.tgz",
+      "integrity": "sha512-D7aPRUUNHRBwHxzxRvp856rjUHRFW1SdQATKXH2hqA0kAZb1hKmi02OpYRacl0TxIGz/ZmXWlbZgjwWYaCakTA==",
+      "cpu": [
+        "x64"
+      ],
+      "optional": true,
+      "os": [
+        "android"
+      ],
+      "engines": {
+        "node": ">=12"
+      }
+    },
+    "node_modules/@esbuild/darwin-arm64": {
+      "version": "0.21.5",
+      "resolved": "https://registry.npmjs.org/@esbuild/darwin-arm64/-/darwin-arm64-0.21.5.tgz",
+      "integrity": "sha512-DwqXqZyuk5AiWWf3UfLiRDJ5EDd49zg6O9wclZ7kUMv2WRFr4HKjXp/5t8JZ11QbQfUS6/cRCKGwYhtNAY88kQ==",
+      "cpu": [
+        "arm64"
+      ],
+      "optional": true,
+      "os": [
+        "darwin"
+      ],
+      "engines": {
+        "node": ">=12"
+      }
+    },
+    "node_modules/@esbuild/darwin-x64": {
+      "version": "0.21.5",
+      "resolved": "https://registry.npmjs.org/@esbuild/darwin-x64/-/darwin-x64-0.21.5.tgz",
+      "integrity": "sha512-se/JjF8NlmKVG4kNIuyWMV/22ZaerB+qaSi5MdrXtd6R08kvs2qCN4C09miupktDitvh8jRFflwGFBQcxZRjbw==",
+      "cpu": [
+        "x64"
+      ],
+      "optional": true,
+      "os": [
+        "darwin"
+      ],
+      "engines": {
+        "node": ">=12"
+      }
+    },
+    "node_modules/@esbuild/freebsd-arm64": {
+      "version": "0.21.5",
+      "resolved": "https://registry.npmjs.org/@esbuild/freebsd-arm64/-/freebsd-arm64-0.21.5.tgz",
+      "integrity": "sha512-5JcRxxRDUJLX8JXp/wcBCy3pENnCgBR9bN6JsY4OmhfUtIHe3ZW0mawA7+RDAcMLrMIZaf03NlQiX9DGyB8h4g==",
+      "cpu": [
+        "arm64"
+      ],
+      "optional": true,
+      "os": [
+        "freebsd"
+      ],
+      "engines": {
+        "node": ">=12"
+      }
+    },
+    "node_modules/@esbuild/freebsd-x64": {
+      "version": "0.21.5",
+      "resolved": "https://registry.npmjs.org/@esbuild/freebsd-x64/-/freebsd-x64-0.21.5.tgz",
+      "integrity": "sha512-J95kNBj1zkbMXtHVH29bBriQygMXqoVQOQYA+ISs0/2l3T9/kj42ow2mpqerRBxDJnmkUDCaQT/dfNXWX/ZZCQ==",
+      "cpu": [
+        "x64"
+      ],
+      "optional": true,
+      "os": [
+        "freebsd"
+      ],
+      "engines": {
+        "node": ">=12"
+      }
+    },
+    "node_modules/@esbuild/linux-arm": {
+      "version": "0.21.5",
+      "resolved": "https://registry.npmjs.org/@esbuild/linux-arm/-/linux-arm-0.21.5.tgz",
+      "integrity": "sha512-bPb5AHZtbeNGjCKVZ9UGqGwo8EUu4cLq68E95A53KlxAPRmUyYv2D6F0uUI65XisGOL1hBP5mTronbgo+0bFcA==",
+      "cpu": [
+        "arm"
+      ],
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">=12"
+      }
+    },
+    "node_modules/@esbuild/linux-arm64": {
+      "version": "0.21.5",
+      "resolved": "https://registry.npmjs.org/@esbuild/linux-arm64/-/linux-arm64-0.21.5.tgz",
+      "integrity": "sha512-ibKvmyYzKsBeX8d8I7MH/TMfWDXBF3db4qM6sy+7re0YXya+K1cem3on9XgdT2EQGMu4hQyZhan7TeQ8XkGp4Q==",
+      "cpu": [
+        "arm64"
+      ],
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">=12"
+      }
+    },
+    "node_modules/@esbuild/linux-ia32": {
+      "version": "0.21.5",
+      "resolved": "https://registry.npmjs.org/@esbuild/linux-ia32/-/linux-ia32-0.21.5.tgz",
+      "integrity": "sha512-YvjXDqLRqPDl2dvRODYmmhz4rPeVKYvppfGYKSNGdyZkA01046pLWyRKKI3ax8fbJoK5QbxblURkwK/MWY18Tg==",
+      "cpu": [
+        "ia32"
+      ],
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">=12"
+      }
+    },
+    "node_modules/@esbuild/linux-loong64": {
+      "version": "0.21.5",
+      "resolved": "https://registry.npmjs.org/@esbuild/linux-loong64/-/linux-loong64-0.21.5.tgz",
+      "integrity": "sha512-uHf1BmMG8qEvzdrzAqg2SIG/02+4/DHB6a9Kbya0XDvwDEKCoC8ZRWI5JJvNdUjtciBGFQ5PuBlpEOXQj+JQSg==",
+      "cpu": [
+        "loong64"
+      ],
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">=12"
+      }
+    },
+    "node_modules/@esbuild/linux-mips64el": {
+      "version": "0.21.5",
+      "resolved": "https://registry.npmjs.org/@esbuild/linux-mips64el/-/linux-mips64el-0.21.5.tgz",
+      "integrity": "sha512-IajOmO+KJK23bj52dFSNCMsz1QP1DqM6cwLUv3W1QwyxkyIWecfafnI555fvSGqEKwjMXVLokcV5ygHW5b3Jbg==",
+      "cpu": [
+        "mips64el"
+      ],
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">=12"
+      }
+    },
+    "node_modules/@esbuild/linux-ppc64": {
+      "version": "0.21.5",
+      "resolved": "https://registry.npmjs.org/@esbuild/linux-ppc64/-/linux-ppc64-0.21.5.tgz",
+      "integrity": "sha512-1hHV/Z4OEfMwpLO8rp7CvlhBDnjsC3CttJXIhBi+5Aj5r+MBvy4egg7wCbe//hSsT+RvDAG7s81tAvpL2XAE4w==",
+      "cpu": [
+        "ppc64"
+      ],
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">=12"
+      }
+    },
+    "node_modules/@esbuild/linux-riscv64": {
+      "version": "0.21.5",
+      "resolved": "https://registry.npmjs.org/@esbuild/linux-riscv64/-/linux-riscv64-0.21.5.tgz",
+      "integrity": "sha512-2HdXDMd9GMgTGrPWnJzP2ALSokE/0O5HhTUvWIbD3YdjME8JwvSCnNGBnTThKGEB91OZhzrJ4qIIxk/SBmyDDA==",
+      "cpu": [
+        "riscv64"
+      ],
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">=12"
+      }
+    },
+    "node_modules/@esbuild/linux-s390x": {
+      "version": "0.21.5",
+      "resolved": "https://registry.npmjs.org/@esbuild/linux-s390x/-/linux-s390x-0.21.5.tgz",
+      "integrity": "sha512-zus5sxzqBJD3eXxwvjN1yQkRepANgxE9lgOW2qLnmr8ikMTphkjgXu1HR01K4FJg8h1kEEDAqDcZQtbrRnB41A==",
+      "cpu": [
+        "s390x"
+      ],
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">=12"
+      }
+    },
+    "node_modules/@esbuild/linux-x64": {
+      "version": "0.21.5",
+      "resolved": "https://registry.npmjs.org/@esbuild/linux-x64/-/linux-x64-0.21.5.tgz",
+      "integrity": "sha512-1rYdTpyv03iycF1+BhzrzQJCdOuAOtaqHTWJZCWvijKD2N5Xu0TtVC8/+1faWqcP9iBCWOmjmhoH94dH82BxPQ==",
+      "cpu": [
+        "x64"
+      ],
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">=12"
+      }
+    },
+    "node_modules/@esbuild/netbsd-x64": {
+      "version": "0.21.5",
+      "resolved": "https://registry.npmjs.org/@esbuild/netbsd-x64/-/netbsd-x64-0.21.5.tgz",
+      "integrity": "sha512-Woi2MXzXjMULccIwMnLciyZH4nCIMpWQAs049KEeMvOcNADVxo0UBIQPfSmxB3CWKedngg7sWZdLvLczpe0tLg==",
+      "cpu": [
+        "x64"
+      ],
+      "optional": true,
+      "os": [
+        "netbsd"
+      ],
+      "engines": {
+        "node": ">=12"
+      }
+    },
+    "node_modules/@esbuild/openbsd-x64": {
+      "version": "0.21.5",
+      "resolved": "https://registry.npmjs.org/@esbuild/openbsd-x64/-/openbsd-x64-0.21.5.tgz",
+      "integrity": "sha512-HLNNw99xsvx12lFBUwoT8EVCsSvRNDVxNpjZ7bPn947b8gJPzeHWyNVhFsaerc0n3TsbOINvRP2byTZ5LKezow==",
+      "cpu": [
+        "x64"
+      ],
+      "optional": true,
+      "os": [
+        "openbsd"
+      ],
+      "engines": {
+        "node": ">=12"
+      }
+    },
+    "node_modules/@esbuild/sunos-x64": {
+      "version": "0.21.5",
+      "resolved": "https://registry.npmjs.org/@esbuild/sunos-x64/-/sunos-x64-0.21.5.tgz",
+      "integrity": "sha512-6+gjmFpfy0BHU5Tpptkuh8+uw3mnrvgs+dSPQXQOv3ekbordwnzTVEb4qnIvQcYXq6gzkyTnoZ9dZG+D4garKg==",
+      "cpu": [
+        "x64"
+      ],
+      "optional": true,
+      "os": [
+        "sunos"
+      ],
+      "engines": {
+        "node": ">=12"
+      }
+    },
+    "node_modules/@esbuild/win32-arm64": {
+      "version": "0.21.5",
+      "resolved": "https://registry.npmjs.org/@esbuild/win32-arm64/-/win32-arm64-0.21.5.tgz",
+      "integrity": "sha512-Z0gOTd75VvXqyq7nsl93zwahcTROgqvuAcYDUr+vOv8uHhNSKROyU961kgtCD1e95IqPKSQKH7tBTslnS3tA8A==",
+      "cpu": [
+        "arm64"
+      ],
+      "optional": true,
+      "os": [
+        "win32"
+      ],
+      "engines": {
+        "node": ">=12"
+      }
+    },
+    "node_modules/@esbuild/win32-ia32": {
+      "version": "0.21.5",
+      "resolved": "https://registry.npmjs.org/@esbuild/win32-ia32/-/win32-ia32-0.21.5.tgz",
+      "integrity": "sha512-SWXFF1CL2RVNMaVs+BBClwtfZSvDgtL//G/smwAc5oVK/UPu2Gu9tIaRgFmYFFKrmg3SyAjSrElf0TiJ1v8fYA==",
+      "cpu": [
+        "ia32"
+      ],
+      "optional": true,
+      "os": [
+        "win32"
+      ],
+      "engines": {
+        "node": ">=12"
+      }
+    },
+    "node_modules/@esbuild/win32-x64": {
+      "version": "0.21.5",
+      "resolved": "https://registry.npmjs.org/@esbuild/win32-x64/-/win32-x64-0.21.5.tgz",
+      "integrity": "sha512-tQd/1efJuzPC6rCFwEvLtci/xNFcTZknmXs98FYDfGE4wP9ClFV98nyKrzJKVPMhdDnjzLhdUyMX4PsQAPjwIw==",
+      "cpu": [
+        "x64"
+      ],
+      "optional": true,
+      "os": [
+        "win32"
+      ],
+      "engines": {
+        "node": ">=12"
+      }
+    },
+    "node_modules/@jridgewell/gen-mapping": {
+      "version": "0.3.13",
+      "resolved": "https://registry.npmjs.org/@jridgewell/gen-mapping/-/gen-mapping-0.3.13.tgz",
+      "integrity": "sha512-2kkt/7niJ6MgEPxF0bYdQ6etZaA+fQvDcLKckhy1yIQOzaoKjBBjSj63/aLVjYE3qhRt5dvM+uUyfCg6UKCBbA==",
+      "dependencies": {
+        "@jridgewell/sourcemap-codec": "^1.5.0",
+        "@jridgewell/trace-mapping": "^0.3.24"
+      }
+    },
+    "node_modules/@jridgewell/remapping": {
+      "version": "2.3.5",
+      "resolved": "https://registry.npmjs.org/@jridgewell/remapping/-/remapping-2.3.5.tgz",
+      "integrity": "sha512-LI9u/+laYG4Ds1TDKSJW2YPrIlcVYOwi2fUC6xB43lueCjgxV4lffOCZCtYFiH6TNOX+tQKXx97T4IKHbhyHEQ==",
+      "dependencies": {
+        "@jridgewell/gen-mapping": "^0.3.5",
+        "@jridgewell/trace-mapping": "^0.3.24"
+      }
+    },
+    "node_modules/@jridgewell/resolve-uri": {
+      "version": "3.1.2",
+      "resolved": "https://registry.npmjs.org/@jridgewell/resolve-uri/-/resolve-uri-3.1.2.tgz",
+      "integrity": "sha512-bRISgCIjP20/tbWSPWMEi54QVPRZExkuD9lJL+UIxUKtwVJA8wW1Trb1jMs1RFXo1CBTNZ/5hpC9QvmKWdopKw==",
+      "engines": {
+        "node": ">=6.0.0"
+      }
+    },
+    "node_modules/@jridgewell/sourcemap-codec": {
+      "version": "1.5.5",
+      "resolved": "https://registry.npmjs.org/@jridgewell/sourcemap-codec/-/sourcemap-codec-1.5.5.tgz",
+      "integrity": "sha512-cYQ9310grqxueWbl+WuIUIaiUaDcj7WOq5fVhEljNVgRfOUhY9fy2zTvfoqWsnebh8Sl70VScFbICvJnLKB0Og=="
+    },
+    "node_modules/@jridgewell/trace-mapping": {
+      "version": "0.3.31",
+      "resolved": "https://registry.npmjs.org/@jridgewell/trace-mapping/-/trace-mapping-0.3.31.tgz",
+      "integrity": "sha512-zzNR+SdQSDJzc8joaeP8QQoCQr8NuYx2dIIytl1QeBEZHJ9uW6hebsrYgbz8hJwUQao3TWCMtmfV8Nu1twOLAw==",
+      "dependencies": {
+        "@jridgewell/resolve-uri": "^3.1.0",
+        "@jridgewell/sourcemap-codec": "^1.4.14"
+      }
+    },
+    "node_modules/@rollup/rollup-android-arm-eabi": {
+      "version": "4.60.2",
+      "resolved": "https://registry.npmjs.org/@rollup/rollup-android-arm-eabi/-/rollup-android-arm-eabi-4.60.2.tgz",
+      "integrity": "sha512-dnlp69efPPg6Uaw2dVqzWRfAWRnYVb1XJ8CyyhIbZeaq4CA5/mLeZ1IEt9QqQxmbdvagjLIm2ZL8BxXv5lH4Yw==",
+      "cpu": [
+        "arm"
+      ],
+      "optional": true,
+      "os": [
+        "android"
+      ]
+    },
+    "node_modules/@rollup/rollup-android-arm64": {
+      "version": "4.60.2",
+      "resolved": "https://registry.npmjs.org/@rollup/rollup-android-arm64/-/rollup-android-arm64-4.60.2.tgz",
+      "integrity": "sha512-OqZTwDRDchGRHHm/hwLOL7uVPB9aUvI0am/eQuWMNyFHf5PSEQmyEeYYheA0EPPKUO/l0uigCp+iaTjoLjVoHg==",
+      "cpu": [
+        "arm64"
+      ],
+      "optional": true,
+      "os": [
+        "android"
+      ]
+    },
+    "node_modules/@rollup/rollup-darwin-arm64": {
+      "version": "4.60.2",
+      "resolved": "https://registry.npmjs.org/@rollup/rollup-darwin-arm64/-/rollup-darwin-arm64-4.60.2.tgz",
+      "integrity": "sha512-UwRE7CGpvSVEQS8gUMBe1uADWjNnVgP3Iusyda1nSRwNDCsRjnGc7w6El6WLQsXmZTbLZx9cecegumcitNfpmA==",
+      "cpu": [
+        "arm64"
+      ],
+      "optional": true,
+      "os": [
+        "darwin"
+      ]
+    },
+    "node_modules/@rollup/rollup-darwin-x64": {
+      "version": "4.60.2",
+      "resolved": "https://registry.npmjs.org/@rollup/rollup-darwin-x64/-/rollup-darwin-x64-4.60.2.tgz",
+      "integrity": "sha512-gjEtURKLCC5VXm1I+2i1u9OhxFsKAQJKTVB8WvDAHF+oZlq0GTVFOlTlO1q3AlCTE/DF32c16ESvfgqR7343/g==",
+      "cpu": [
+        "x64"
+      ],
+      "optional": true,
+      "os": [
+        "darwin"
+      ]
+    },
+    "node_modules/@rollup/rollup-freebsd-arm64": {
+      "version": "4.60.2",
+      "resolved": "https://registry.npmjs.org/@rollup/rollup-freebsd-arm64/-/rollup-freebsd-arm64-4.60.2.tgz",
+      "integrity": "sha512-Bcl6CYDeAgE70cqZaMojOi/eK63h5Me97ZqAQoh77VPjMysA/4ORQBRGo3rRy45x4MzVlU9uZxs8Uwy7ZaKnBw==",
+      "cpu": [
+        "arm64"
+      ],
+      "optional": true,
+      "os": [
+        "freebsd"
+      ]
+    },
+    "node_modules/@rollup/rollup-freebsd-x64": {
+      "version": "4.60.2",
+      "resolved": "https://registry.npmjs.org/@rollup/rollup-freebsd-x64/-/rollup-freebsd-x64-4.60.2.tgz",
+      "integrity": "sha512-LU+TPda3mAE2QB0/Hp5VyeKJivpC6+tlOXd1VMoXV/YFMvk/MNk5iXeBfB4MQGRWyOYVJ01625vjkr0Az98OJQ==",
+      "cpu": [
+        "x64"
+      ],
+      "optional": true,
+      "os": [
+        "freebsd"
+      ]
+    },
+    "node_modules/@rollup/rollup-linux-arm-gnueabihf": {
+      "version": "4.60.2",
+      "resolved": "https://registry.npmjs.org/@rollup/rollup-linux-arm-gnueabihf/-/rollup-linux-arm-gnueabihf-4.60.2.tgz",
+      "integrity": "sha512-2QxQrM+KQ7DAW4o22j+XZ6RKdxjLD7BOWTP0Bv0tmjdyhXSsr2Ul1oJDQqh9Zf5qOwTuTc7Ek83mOFaKnodPjg==",
+      "cpu": [
+        "arm"
+      ],
+      "optional": true,
+      "os": [
+        "linux"
+      ]
+    },
+    "node_modules/@rollup/rollup-linux-arm-musleabihf": {
+      "version": "4.60.2",
+      "resolved": "https://registry.npmjs.org/@rollup/rollup-linux-arm-musleabihf/-/rollup-linux-arm-musleabihf-4.60.2.tgz",
+      "integrity": "sha512-TbziEu2DVsTEOPif2mKWkMeDMLoYjx95oESa9fkQQK7r/Orta0gnkcDpzwufEcAO2BLBsD7mZkXGFqEdMRRwfw==",
+      "cpu": [
+        "arm"
+      ],
+      "optional": true,
+      "os": [
+        "linux"
+      ]
+    },
+    "node_modules/@rollup/rollup-linux-arm64-gnu": {
+      "version": "4.60.2",
+      "resolved": "https://registry.npmjs.org/@rollup/rollup-linux-arm64-gnu/-/rollup-linux-arm64-gnu-4.60.2.tgz",
+      "integrity": "sha512-bO/rVDiDUuM2YfuCUwZ1t1cP+/yqjqz+Xf2VtkdppefuOFS2OSeAfgafaHNkFn0t02hEyXngZkxtGqXcXwO8Rg==",
+      "cpu": [
+        "arm64"
+      ],
+      "optional": true,
+      "os": [
+        "linux"
+      ]
+    },
+    "node_modules/@rollup/rollup-linux-arm64-musl": {
+      "version": "4.60.2",
+      "resolved": "https://registry.npmjs.org/@rollup/rollup-linux-arm64-musl/-/rollup-linux-arm64-musl-4.60.2.tgz",
+      "integrity": "sha512-hr26p7e93Rl0Za+JwW7EAnwAvKkehh12BU1Llm9Ykiibg4uIr2rbpxG9WCf56GuvidlTG9KiiQT/TXT1yAWxTA==",
+      "cpu": [
+        "arm64"
+      ],
+      "optional": true,
+      "os": [
+        "linux"
+      ]
+    },
+    "node_modules/@rollup/rollup-linux-loong64-gnu": {
+      "version": "4.60.2",
+      "resolved": "https://registry.npmjs.org/@rollup/rollup-linux-loong64-gnu/-/rollup-linux-loong64-gnu-4.60.2.tgz",
+      "integrity": "sha512-pOjB/uSIyDt+ow3k/RcLvUAOGpysT2phDn7TTUB3n75SlIgZzM6NKAqlErPhoFU+npgY3/n+2HYIQVbF70P9/A==",
+      "cpu": [
+        "loong64"
+      ],
+      "optional": true,
+      "os": [
+        "linux"
+      ]
+    },
+    "node_modules/@rollup/rollup-linux-loong64-musl": {
+      "version": "4.60.2",
+      "resolved": "https://registry.npmjs.org/@rollup/rollup-linux-loong64-musl/-/rollup-linux-loong64-musl-4.60.2.tgz",
+      "integrity": "sha512-2/w+q8jszv9Ww1c+6uJT3OwqhdmGP2/4T17cu8WuwyUuuaCDDJ2ojdyYwZzCxx0GcsZBhzi3HmH+J5pZNXnd+Q==",
+      "cpu": [
+        "loong64"
+      ],
+      "optional": true,
+      "os": [
+        "linux"
+      ]
+    },
+    "node_modules/@rollup/rollup-linux-ppc64-gnu": {
+      "version": "4.60.2",
+      "resolved": "https://registry.npmjs.org/@rollup/rollup-linux-ppc64-gnu/-/rollup-linux-ppc64-gnu-4.60.2.tgz",
+      "integrity": "sha512-11+aL5vKheYgczxtPVVRhdptAM2H7fcDR5Gw4/bTcteuZBlH4oP9f5s9zYO9aGZvoGeBpqXI/9TZZihZ609wKw==",
+      "cpu": [
+        "ppc64"
+      ],
+      "optional": true,
+      "os": [
+        "linux"
+      ]
+    },
+    "node_modules/@rollup/rollup-linux-ppc64-musl": {
+      "version": "4.60.2",
+      "resolved": "https://registry.npmjs.org/@rollup/rollup-linux-ppc64-musl/-/rollup-linux-ppc64-musl-4.60.2.tgz",
+      "integrity": "sha512-i16fokAGK46IVZuV8LIIwMdtqhin9hfYkCh8pf8iC3QU3LpwL+1FSFGej+O7l3E/AoknL6Dclh2oTdnRMpTzFQ==",
+      "cpu": [
+        "ppc64"
+      ],
+      "optional": true,
+      "os": [
+        "linux"
+      ]
+    },
+    "node_modules/@rollup/rollup-linux-riscv64-gnu": {
+      "version": "4.60.2",
+      "resolved": "https://registry.npmjs.org/@rollup/rollup-linux-riscv64-gnu/-/rollup-linux-riscv64-gnu-4.60.2.tgz",
+      "integrity": "sha512-49FkKS6RGQoriDSK/6E2GkAsAuU5kETFCh7pG4yD/ylj9rKhTmO3elsnmBvRD4PgJPds5W2PkhC82aVwmUcJ7A==",
+      "cpu": [
+        "riscv64"
+      ],
+      "optional": true,
+      "os": [
+        "linux"
+      ]
+    },
+    "node_modules/@rollup/rollup-linux-riscv64-musl": {
+      "version": "4.60.2",
+      "resolved": "https://registry.npmjs.org/@rollup/rollup-linux-riscv64-musl/-/rollup-linux-riscv64-musl-4.60.2.tgz",
+      "integrity": "sha512-mjYNkHPfGpUR00DuM1ZZIgs64Hpf4bWcz9Z41+4Q+pgDx73UwWdAYyf6EG/lRFldmdHHzgrYyge5akFUW0D3mQ==",
+      "cpu": [
+        "riscv64"
+      ],
+      "optional": true,
+      "os": [
+        "linux"
+      ]
+    },
+    "node_modules/@rollup/rollup-linux-s390x-gnu": {
+      "version": "4.60.2",
+      "resolved": "https://registry.npmjs.org/@rollup/rollup-linux-s390x-gnu/-/rollup-linux-s390x-gnu-4.60.2.tgz",
+      "integrity": "sha512-ALyvJz965BQk8E9Al/JDKKDLH2kfKFLTGMlgkAbbYtZuJt9LU8DW3ZoDMCtQpXAltZxwBHevXz5u+gf0yA0YoA==",
+      "cpu": [
+        "s390x"
+      ],
+      "optional": true,
+      "os": [
+        "linux"
+      ]
+    },
+    "node_modules/@rollup/rollup-linux-x64-gnu": {
+      "version": "4.60.2",
+      "resolved": "https://registry.npmjs.org/@rollup/rollup-linux-x64-gnu/-/rollup-linux-x64-gnu-4.60.2.tgz",
+      "integrity": "sha512-UQjrkIdWrKI626Du8lCQ6MJp/6V1LAo2bOK9OTu4mSn8GGXIkPXk/Vsp4bLHCd9Z9Iz2OTEaokUE90VweJgIYQ==",
+      "cpu": [
+        "x64"
+      ],
+      "optional": true,
+      "os": [
+        "linux"
+      ]
+    },
+    "node_modules/@rollup/rollup-linux-x64-musl": {
+      "version": "4.60.2",
+      "resolved": "https://registry.npmjs.org/@rollup/rollup-linux-x64-musl/-/rollup-linux-x64-musl-4.60.2.tgz",
+      "integrity": "sha512-bTsRGj6VlSdn/XD4CGyzMnzaBs9bsRxy79eTqTCBsA8TMIEky7qg48aPkvJvFe1HyzQ5oMZdg7AnVlWQSKLTnw==",
+      "cpu": [
+        "x64"
+      ],
+      "optional": true,
+      "os": [
+        "linux"
+      ]
+    },
+    "node_modules/@rollup/rollup-openbsd-x64": {
+      "version": "4.60.2",
+      "resolved": "https://registry.npmjs.org/@rollup/rollup-openbsd-x64/-/rollup-openbsd-x64-4.60.2.tgz",
+      "integrity": "sha512-6d4Z3534xitaA1FcMWP7mQPq5zGwBmGbhphh2DwaA1aNIXUu3KTOfwrWpbwI4/Gr0uANo7NTtaykFyO2hPuFLg==",
+      "cpu": [
+        "x64"
+      ],
+      "optional": true,
+      "os": [
+        "openbsd"
+      ]
+    },
+    "node_modules/@rollup/rollup-openharmony-arm64": {
+      "version": "4.60.2",
+      "resolved": "https://registry.npmjs.org/@rollup/rollup-openharmony-arm64/-/rollup-openharmony-arm64-4.60.2.tgz",
+      "integrity": "sha512-NetAg5iO2uN7eB8zE5qrZ3CSil+7IJt4WDFLcC75Ymywq1VZVD6qJ6EvNLjZ3rEm6gB7XW5JdT60c6MN35Z85Q==",
+      "cpu": [
+        "arm64"
+      ],
+      "optional": true,
+      "os": [
+        "openharmony"
+      ]
+    },
+    "node_modules/@rollup/rollup-win32-arm64-msvc": {
+      "version": "4.60.2",
+      "resolved": "https://registry.npmjs.org/@rollup/rollup-win32-arm64-msvc/-/rollup-win32-arm64-msvc-4.60.2.tgz",
+      "integrity": "sha512-NCYhOotpgWZ5kdxCZsv6Iudx0wX8980Q/oW4pNFNihpBKsDbEA1zpkfxJGC0yugsUuyDZ7gL37dbzwhR0VI7pQ==",
+      "cpu": [
+        "arm64"
+      ],
+      "optional": true,
+      "os": [
+        "win32"
+      ]
+    },
+    "node_modules/@rollup/rollup-win32-ia32-msvc": {
+      "version": "4.60.2",
+      "resolved": "https://registry.npmjs.org/@rollup/rollup-win32-ia32-msvc/-/rollup-win32-ia32-msvc-4.60.2.tgz",
+      "integrity": "sha512-RXsaOqXxfoUBQoOgvmmijVxJnW2IGB0eoMO7F8FAjaj0UTywUO/luSqimWBJn04WNgUkeNhh7fs7pESXajWmkg==",
+      "cpu": [
+        "ia32"
+      ],
+      "optional": true,
+      "os": [
+        "win32"
+      ]
+    },
+    "node_modules/@rollup/rollup-win32-x64-gnu": {
+      "version": "4.60.2",
+      "resolved": "https://registry.npmjs.org/@rollup/rollup-win32-x64-gnu/-/rollup-win32-x64-gnu-4.60.2.tgz",
+      "integrity": "sha512-qdAzEULD+/hzObedtmV6iBpdL5TIbKVztGiK7O3/KYSf+HIzU257+MX1EXJcyIiDbMAqmbwaufcYPvyRryeZtA==",
+      "cpu": [
+        "x64"
+      ],
+      "optional": true,
+      "os": [
+        "win32"
+      ]
+    },
+    "node_modules/@rollup/rollup-win32-x64-msvc": {
+      "version": "4.60.2",
+      "resolved": "https://registry.npmjs.org/@rollup/rollup-win32-x64-msvc/-/rollup-win32-x64-msvc-4.60.2.tgz",
+      "integrity": "sha512-Nd/SgG27WoA9e+/TdK74KnHz852TLa94ovOYySo/yMPuTmpckK/jIF2jSwS3g7ELSKXK13/cVdmg1Z/DaCWKxA==",
+      "cpu": [
+        "x64"
+      ],
+      "optional": true,
+      "os": [
+        "win32"
+      ]
+    },
+    "node_modules/@types/babel__core": {
+      "version": "7.20.5",
+      "resolved": "https://registry.npmjs.org/@types/babel__core/-/babel__core-7.20.5.tgz",
+      "integrity": "sha512-qoQprZvz5wQFJwMDqeseRXWv3rqMvhgpbXFfVyWhbx9X47POIA6i/+dXefEmZKoAgOaTdaIgNSMqMIU61yRyzA==",
+      "dependencies": {
+        "@babel/parser": "^7.20.7",
+        "@babel/types": "^7.20.7",
+        "@types/babel__generator": "*",
+        "@types/babel__template": "*",
+        "@types/babel__traverse": "*"
+      }
+    },
+    "node_modules/@types/babel__generator": {
+      "version": "7.27.0",
+      "resolved": "https://registry.npmjs.org/@types/babel__generator/-/babel__generator-7.27.0.tgz",
+      "integrity": "sha512-ufFd2Xi92OAVPYsy+P4n7/U7e68fex0+Ee8gSG9KX7eo084CWiQ4sdxktvdl0bOPupXtVJPY19zk6EwWqUQ8lg==",
+      "dependencies": {
+        "@babel/types": "^7.0.0"
+      }
+    },
+    "node_modules/@types/babel__template": {
+      "version": "7.4.4",
+      "resolved": "https://registry.npmjs.org/@types/babel__template/-/babel__template-7.4.4.tgz",
+      "integrity": "sha512-h/NUaSyG5EyxBIp8YRxo4RMe2/qQgvyowRwVMzhYhBCONbW8PUsg4lkFMrhgZhUe5z3L3MiLDuvyJ/CaPa2A8A==",
+      "dependencies": {
+        "@babel/parser": "^7.1.0",
+        "@babel/types": "^7.0.0"
+      }
+    },
+    "node_modules/@types/babel__traverse": {
+      "version": "7.28.0",
+      "resolved": "https://registry.npmjs.org/@types/babel__traverse/-/babel__traverse-7.28.0.tgz",
+      "integrity": "sha512-8PvcXf70gTDZBgt9ptxJ8elBeBjcLOAcOtoO/mPJjtji1+CdGbHgm77om1GrsPxsiE+uXIpNSK64UYaIwQXd4Q==",
+      "dependencies": {
+        "@babel/types": "^7.28.2"
+      }
+    },
+    "node_modules/@types/estree": {
+      "version": "1.0.8",
+      "resolved": "https://registry.npmjs.org/@types/estree/-/estree-1.0.8.tgz",
+      "integrity": "sha512-dWHzHa2WqEXI/O1E9OjrocMTKJl2mSrEolh1Iomrv6U+JuNwaHXsXx9bLu5gG7BUWFIN0skIQJQ/L1rIex4X6w=="
+    },
+    "node_modules/@types/prop-types": {
+      "version": "15.7.15",
+      "resolved": "https://registry.npmjs.org/@types/prop-types/-/prop-types-15.7.15.tgz",
+      "integrity": "sha512-F6bEyamV9jKGAFBEmlQnesRPGOQqS2+Uwi0Em15xenOxHaf2hv6L8YCVn3rPdPJOiJfPiCnLIRyvwVaqMY3MIw==",
+      "dev": true
+    },
+    "node_modules/@types/react": {
+      "version": "18.3.12",
+      "resolved": "https://registry.npmjs.org/@types/react/-/react-18.3.12.tgz",
+      "integrity": "sha512-D2wOSq/d6Agt28q7rSI3jhU7G6aiuzljDGZ2hTZHIkrTLUI+AF3WMeKkEZ9nN2fkBAlcktT6vcZjDFiIhMYEQw==",
+      "dev": true,
+      "dependencies": {
+        "@types/prop-types": "*",
+        "csstype": "^3.0.2"
+      }
+    },
+    "node_modules/@types/react-dom": {
+      "version": "18.3.1",
+      "resolved": "https://registry.npmjs.org/@types/react-dom/-/react-dom-18.3.1.tgz",
+      "integrity": "sha512-qW1Mfv8taImTthu4KoXgDfLuk4bydU6Q/TkADnDWWHwi4NX4BR+LWfTp2sVmTqRrsHvyDDTelgelxJ+SsejKKQ==",
+      "dev": true,
+      "dependencies": {
+        "@types/react": "*"
+      }
+    },
+    "node_modules/@vitejs/plugin-react": {
+      "version": "4.3.4",
+      "resolved": "https://registry.npmjs.org/@vitejs/plugin-react/-/plugin-react-4.3.4.tgz",
+      "integrity": "sha512-SCCPBJtYLdE8PX/7ZQAs1QAZ8Jqwih+0VBLum1EGqmCCQal+MIUqLCzj3ZUy8ufbC0cAM4LRlSTm7IQJwWT4ug==",
+      "dependencies": {
+        "@babel/core": "^7.26.0",
+        "@babel/plugin-transform-react-jsx-self": "^7.25.9",
+        "@babel/plugin-transform-react-jsx-source": "^7.25.9",
+        "@types/babel__core": "^7.20.5",
+        "react-refresh": "^0.14.2"
+      },
+      "engines": {
+        "node": "^14.18.0 || >=16.0.0"
+      },
+      "peerDependencies": {
+        "vite": "^4.2.0 || ^5.0.0 || ^6.0.0"
+      }
+    },
+    "node_modules/baseline-browser-mapping": {
+      "version": "2.10.23",
+      "resolved": "https://registry.npmjs.org/baseline-browser-mapping/-/baseline-browser-mapping-2.10.23.tgz",
+      "integrity": "sha512-xwVXGqevyKPsiuQdLj+dZMVjidjJV508TBqexND5HrF89cGdCYCJFB3qhcxRHSeMctdCfbR1jrxBajhDy7o29g==",
+      "bin": {
+        "baseline-browser-mapping": "dist/cli.cjs"
+      },
+      "engines": {
+        "node": ">=6.0.0"
+      }
+    },
+    "node_modules/browserslist": {
+      "version": "4.28.2",
+      "resolved": "https://registry.npmjs.org/browserslist/-/browserslist-4.28.2.tgz",
+      "integrity": "sha512-48xSriZYYg+8qXna9kwqjIVzuQxi+KYWp2+5nCYnYKPTr0LvD89Jqk2Or5ogxz0NUMfIjhh2lIUX/LyX9B4oIg==",
+      "funding": [
+        {
+          "type": "opencollective",
+          "url": "https://opencollective.com/browserslist"
+        },
+        {
+          "type": "tidelift",
+          "url": "https://tidelift.com/funding/github/npm/browserslist"
+        },
+        {
+          "type": "github",
+          "url": "https://github.com/sponsors/ai"
+        }
+      ],
+      "dependencies": {
+        "baseline-browser-mapping": "^2.10.12",
+        "caniuse-lite": "^1.0.30001782",
+        "electron-to-chromium": "^1.5.328",
+        "node-releases": "^2.0.36",
+        "update-browserslist-db": "^1.2.3"
+      },
+      "bin": {
+        "browserslist": "cli.js"
+      },
+      "engines": {
+        "node": "^6 || ^7 || ^8 || ^9 || ^10 || ^11 || ^12 || >=13.7"
+      }
+    },
+    "node_modules/caniuse-lite": {
+      "version": "1.0.30001791",
+      "resolved": "https://registry.npmjs.org/caniuse-lite/-/caniuse-lite-1.0.30001791.tgz",
+      "integrity": "sha512-yk0l/YSrOnFZk3UROpDLQD9+kC1l4meK/wed583AXrzoarMGJcbRi2Q4RaUYbKxYAsZ8sWmaSa/DsLmdBeI1vQ==",
+      "funding": [
+        {
+          "type": "opencollective",
+          "url": "https://opencollective.com/browserslist"
+        },
+        {
+          "type": "tidelift",
+          "url": "https://tidelift.com/funding/github/npm/caniuse-lite"
+        },
+        {
+          "type": "github",
+          "url": "https://github.com/sponsors/ai"
+        }
+      ]
+    },
+    "node_modules/convert-source-map": {
+      "version": "2.0.0",
+      "resolved": "https://registry.npmjs.org/convert-source-map/-/convert-source-map-2.0.0.tgz",
+      "integrity": "sha512-Kvp459HrV2FEJ1CAsi1Ku+MY3kasH19TFykTz2xWmMeq6bk2NU3XXvfJ+Q61m0xktWwt+1HSYf3JZsTms3aRJg=="
+    },
+    "node_modules/csstype": {
+      "version": "3.2.3",
+      "resolved": "https://registry.npmjs.org/csstype/-/csstype-3.2.3.tgz",
+      "integrity": "sha512-z1HGKcYy2xA8AGQfwrn0PAy+PB7X/GSj3UVJW9qKyn43xWa+gl5nXmU4qqLMRzWVLFC8KusUX8T/0kCiOYpAIQ==",
+      "dev": true
+    },
+    "node_modules/debug": {
+      "version": "4.4.3",
+      "resolved": "https://registry.npmjs.org/debug/-/debug-4.4.3.tgz",
+      "integrity": "sha512-RGwwWnwQvkVfavKVt22FGLw+xYSdzARwm0ru6DhTVA3umU5hZc28V3kO4stgYryrTlLpuvgI9GiijltAjNbcqA==",
+      "dependencies": {
+        "ms": "^2.1.3"
+      },
+      "engines": {
+        "node": ">=6.0"
+      },
+      "peerDependenciesMeta": {
+        "supports-color": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/electron-to-chromium": {
+      "version": "1.5.344",
+      "resolved": "https://registry.npmjs.org/electron-to-chromium/-/electron-to-chromium-1.5.344.tgz",
+      "integrity": "sha512-4MxfbmNDm+KPh066EZy+eUnkcDPcZ35wNmOWzFuh/ijvHsve6kbLTLURy88uCNK5FbpN+yk2nQY6BYh1GEt+wg=="
+    },
+    "node_modules/esbuild": {
+      "version": "0.21.5",
+      "resolved": "https://registry.npmjs.org/esbuild/-/esbuild-0.21.5.tgz",
+      "integrity": "sha512-mg3OPMV4hXywwpoDxu3Qda5xCKQi+vCTZq8S9J/EpkhB2HzKXq4SNFZE3+NK93JYxc8VMSep+lOUSC/RVKaBqw==",
+      "hasInstallScript": true,
+      "bin": {
+        "esbuild": "bin/esbuild"
+      },
+      "engines": {
+        "node": ">=12"
+      },
+      "optionalDependencies": {
+        "@esbuild/aix-ppc64": "0.21.5",
+        "@esbuild/android-arm": "0.21.5",
+        "@esbuild/android-arm64": "0.21.5",
+        "@esbuild/android-x64": "0.21.5",
+        "@esbuild/darwin-arm64": "0.21.5",
+        "@esbuild/darwin-x64": "0.21.5",
+        "@esbuild/freebsd-arm64": "0.21.5",
+        "@esbuild/freebsd-x64": "0.21.5",
+        "@esbuild/linux-arm": "0.21.5",
+        "@esbuild/linux-arm64": "0.21.5",
+        "@esbuild/linux-ia32": "0.21.5",
+        "@esbuild/linux-loong64": "0.21.5",
+        "@esbuild/linux-mips64el": "0.21.5",
+        "@esbuild/linux-ppc64": "0.21.5",
+        "@esbuild/linux-riscv64": "0.21.5",
+        "@esbuild/linux-s390x": "0.21.5",
+        "@esbuild/linux-x64": "0.21.5",
+        "@esbuild/netbsd-x64": "0.21.5",
+        "@esbuild/openbsd-x64": "0.21.5",
+        "@esbuild/sunos-x64": "0.21.5",
+        "@esbuild/win32-arm64": "0.21.5",
+        "@esbuild/win32-ia32": "0.21.5",
+        "@esbuild/win32-x64": "0.21.5"
+      }
+    },
+    "node_modules/escalade": {
+      "version": "3.2.0",
+      "resolved": "https://registry.npmjs.org/escalade/-/escalade-3.2.0.tgz",
+      "integrity": "sha512-WUj2qlxaQtO4g6Pq5c29GTcWGDyd8itL8zTlipgECz3JesAiiOKotd8JU6otB3PACgG6xkJUyVhboMS+bje/jA==",
+      "engines": {
+        "node": ">=6"
+      }
+    },
+    "node_modules/fsevents": {
+      "version": "2.3.3",
+      "resolved": "https://registry.npmjs.org/fsevents/-/fsevents-2.3.3.tgz",
+      "integrity": "sha512-5xoDfX+fL7faATnagmWPpbFtwh/R77WmMMqqHGS65C3vvB0YHrgF+B1YmZ3441tMj5n63k0212XNoJwzlhffQw==",
+      "hasInstallScript": true,
+      "optional": true,
+      "os": [
+        "darwin"
+      ],
+      "engines": {
+        "node": "^8.16.0 || ^10.6.0 || >=11.0.0"
+      }
+    },
+    "node_modules/gensync": {
+      "version": "1.0.0-beta.2",
+      "resolved": "https://registry.npmjs.org/gensync/-/gensync-1.0.0-beta.2.tgz",
+      "integrity": "sha512-3hN7NaskYvMDLQY55gnW3NQ+mesEAepTqlg+VEbj7zzqEMBVNhzcGYYeqFo/TlYz6eQiFcp1HcsCZO+nGgS8zg==",
+      "engines": {
+        "node": ">=6.9.0"
+      }
+    },
+    "node_modules/js-tokens": {
+      "version": "4.0.0",
+      "resolved": "https://registry.npmjs.org/js-tokens/-/js-tokens-4.0.0.tgz",
+      "integrity": "sha512-RdJUflcE3cUzKiMqQgsCu06FPu9UdIJO0beYbPhHN4k6apgJtifcoCtT9bcxOpYBtpD2kCM6Sbzg4CausW/PKQ=="
+    },
+    "node_modules/jsesc": {
+      "version": "3.1.0",
+      "resolved": "https://registry.npmjs.org/jsesc/-/jsesc-3.1.0.tgz",
+      "integrity": "sha512-/sM3dO2FOzXjKQhJuo0Q173wf2KOo8t4I8vHy6lF9poUp7bKT0/NHE8fPX23PwfhnykfqnC2xRxOnVw5XuGIaA==",
+      "bin": {
+        "jsesc": "bin/jsesc"
+      },
+      "engines": {
+        "node": ">=6"
+      }
+    },
+    "node_modules/json5": {
+      "version": "2.2.3",
+      "resolved": "https://registry.npmjs.org/json5/-/json5-2.2.3.tgz",
+      "integrity": "sha512-XmOWe7eyHYH14cLdVPoyg+GOH3rYX++KpzrylJwSW98t3Nk+U8XOl8FWKOgwtzdb8lXGf6zYwDUzeHMWfxasyg==",
+      "bin": {
+        "json5": "lib/cli.js"
+      },
+      "engines": {
+        "node": ">=6"
+      }
+    },
+    "node_modules/loose-envify": {
+      "version": "1.4.0",
+      "resolved": "https://registry.npmjs.org/loose-envify/-/loose-envify-1.4.0.tgz",
+      "integrity": "sha512-lyuxPGr/Wfhrlem2CL/UcnUc1zcqKAImBDzukY7Y5F/yQiNdko6+fRLevlw1HgMySw7f611UIY408EtxRSoK3Q==",
+      "dependencies": {
+        "js-tokens": "^3.0.0 || ^4.0.0"
+      },
+      "bin": {
+        "loose-envify": "cli.js"
+      }
+    },
+    "node_modules/lru-cache": {
+      "version": "5.1.1",
+      "resolved": "https://registry.npmjs.org/lru-cache/-/lru-cache-5.1.1.tgz",
+      "integrity": "sha512-KpNARQA3Iwv+jTA0utUVVbrh+Jlrr1Fv0e56GGzAFOXN7dk/FviaDW8LHmK52DlcH4WP2n6gI8vN1aesBFgo9w==",
+      "dependencies": {
+        "yallist": "^3.0.2"
+      }
+    },
+    "node_modules/ms": {
+      "version": "2.1.3",
+      "resolved": "https://registry.npmjs.org/ms/-/ms-2.1.3.tgz",
+      "integrity": "sha512-6FlzubTLZG3J2a/NVCAleEhjzq5oxgHyaCU9yYXvcLsvoVaHJq/s5xXI6/XXP6tz7R9xAOtHnSO/tXtF3WRTlA=="
+    },
+    "node_modules/nanoid": {
+      "version": "3.3.11",
+      "resolved": "https://registry.npmjs.org/nanoid/-/nanoid-3.3.11.tgz",
+      "integrity": "sha512-N8SpfPUnUp1bK+PMYW8qSWdl9U+wwNWI4QKxOYDy9JAro3WMX7p2OeVRF9v+347pnakNevPmiHhNmZ2HbFA76w==",
+      "funding": [
+        {
+          "type": "github",
+          "url": "https://github.com/sponsors/ai"
+        }
+      ],
+      "bin": {
+        "nanoid": "bin/nanoid.cjs"
+      },
+      "engines": {
+        "node": "^10 || ^12 || ^13.7 || ^14 || >=15.0.1"
+      }
+    },
+    "node_modules/node-releases": {
+      "version": "2.0.38",
+      "resolved": "https://registry.npmjs.org/node-releases/-/node-releases-2.0.38.tgz",
+      "integrity": "sha512-3qT/88Y3FbH/Kx4szpQQ4HzUbVrHPKTLVpVocKiLfoYvw9XSGOX2FmD2d6DrXbVYyAQTF2HeF6My8jmzx7/CRw=="
+    },
+    "node_modules/picocolors": {
+      "version": "1.1.1",
+      "resolved": "https://registry.npmjs.org/picocolors/-/picocolors-1.1.1.tgz",
+      "integrity": "sha512-xceH2snhtb5M9liqDsmEw56le376mTZkEX/jEb/RxNFyegNul7eNslCXP9FDj/Lcu0X8KEyMceP2ntpaHrDEVA=="
+    },
+    "node_modules/postcss": {
+      "version": "8.5.12",
+      "resolved": "https://registry.npmjs.org/postcss/-/postcss-8.5.12.tgz",
+      "integrity": "sha512-W62t/Se6rA0Az3DfCL0AqJwXuKwBeYg6nOaIgzP+xZ7N5BFCI7DYi1qs6ygUYT6rvfi6t9k65UMLJC+PHZpDAA==",
+      "funding": [
+        {
+          "type": "opencollective",
+          "url": "https://opencollective.com/postcss/"
+        },
+        {
+          "type": "tidelift",
+          "url": "https://tidelift.com/funding/github/npm/postcss"
+        },
+        {
+          "type": "github",
+          "url": "https://github.com/sponsors/ai"
+        }
+      ],
+      "dependencies": {
+        "nanoid": "^3.3.11",
+        "picocolors": "^1.1.1",
+        "source-map-js": "^1.2.1"
+      },
+      "engines": {
+        "node": "^10 || ^12 || >=14"
+      }
+    },
+    "node_modules/react": {
+      "version": "18.3.1",
+      "resolved": "https://registry.npmjs.org/react/-/react-18.3.1.tgz",
+      "integrity": "sha512-wS+hAgJShR0KhEvPJArfuPVN1+Hz1t0Y6n5jLrGQbkb4urgPE/0Rve+1kMB1v/oWgHgm4WIcV+i7F2pTVj+2iQ==",
+      "dependencies": {
+        "loose-envify": "^1.1.0"
+      },
+      "engines": {
+        "node": ">=0.10.0"
+      }
+    },
+    "node_modules/react-dom": {
+      "version": "18.3.1",
+      "resolved": "https://registry.npmjs.org/react-dom/-/react-dom-18.3.1.tgz",
+      "integrity": "sha512-5m4nQKp+rZRb09LNH59GM4BxTh9251/ylbKIbpe7TpGxfJ+9kv6BLkLBXIjjspbgbnIBNqlI23tRnTWT0snUIw==",
+      "dependencies": {
+        "loose-envify": "^1.1.0",
+        "scheduler": "^0.23.2"
+      },
+      "peerDependencies": {
+        "react": "^18.3.1"
+      }
+    },
+    "node_modules/react-refresh": {
+      "version": "0.14.2",
+      "resolved": "https://registry.npmjs.org/react-refresh/-/react-refresh-0.14.2.tgz",
+      "integrity": "sha512-jCvmsr+1IUSMUyzOkRcvnVbX3ZYC6g9TDrDbFuFmRDq7PD4yaGbLKNQL6k2jnArV8hjYxh7hVhAZB6s9HDGpZA==",
+      "engines": {
+        "node": ">=0.10.0"
+      }
+    },
+    "node_modules/rollup": {
+      "version": "4.60.2",
+      "resolved": "https://registry.npmjs.org/rollup/-/rollup-4.60.2.tgz",
+      "integrity": "sha512-J9qZyW++QK/09NyN/zeO0dG/1GdGfyp9lV8ajHnRVLfo/uFsbji5mHnDgn/qYdUHyCkM2N+8VyspgZclfAh0eQ==",
+      "dependencies": {
+        "@types/estree": "1.0.8"
+      },
+      "bin": {
+        "rollup": "dist/bin/rollup"
+      },
+      "engines": {
+        "node": ">=18.0.0",
+        "npm": ">=8.0.0"
+      },
+      "optionalDependencies": {
+        "@rollup/rollup-android-arm-eabi": "4.60.2",
+        "@rollup/rollup-android-arm64": "4.60.2",
+        "@rollup/rollup-darwin-arm64": "4.60.2",
+        "@rollup/rollup-darwin-x64": "4.60.2",
+        "@rollup/rollup-freebsd-arm64": "4.60.2",
+        "@rollup/rollup-freebsd-x64": "4.60.2",
+        "@rollup/rollup-linux-arm-gnueabihf": "4.60.2",
+        "@rollup/rollup-linux-arm-musleabihf": "4.60.2",
+        "@rollup/rollup-linux-arm64-gnu": "4.60.2",
+        "@rollup/rollup-linux-arm64-musl": "4.60.2",
+        "@rollup/rollup-linux-loong64-gnu": "4.60.2",
+        "@rollup/rollup-linux-loong64-musl": "4.60.2",
+        "@rollup/rollup-linux-ppc64-gnu": "4.60.2",
+        "@rollup/rollup-linux-ppc64-musl": "4.60.2",
+        "@rollup/rollup-linux-riscv64-gnu": "4.60.2",
+        "@rollup/rollup-linux-riscv64-musl": "4.60.2",
+        "@rollup/rollup-linux-s390x-gnu": "4.60.2",
+        "@rollup/rollup-linux-x64-gnu": "4.60.2",
+        "@rollup/rollup-linux-x64-musl": "4.60.2",
+        "@rollup/rollup-openbsd-x64": "4.60.2",
+        "@rollup/rollup-openharmony-arm64": "4.60.2",
+        "@rollup/rollup-win32-arm64-msvc": "4.60.2",
+        "@rollup/rollup-win32-ia32-msvc": "4.60.2",
+        "@rollup/rollup-win32-x64-gnu": "4.60.2",
+        "@rollup/rollup-win32-x64-msvc": "4.60.2",
+        "fsevents": "~2.3.2"
+      }
+    },
+    "node_modules/scheduler": {
+      "version": "0.23.2",
+      "resolved": "https://registry.npmjs.org/scheduler/-/scheduler-0.23.2.tgz",
+      "integrity": "sha512-UOShsPwz7NrMUqhR6t0hWjFduvOzbtv7toDH1/hIrfRNIDBnnBWd0CwJTGvTpngVlmwGCdP9/Zl/tVrDqcuYzQ==",
+      "dependencies": {
+        "loose-envify": "^1.1.0"
+      }
+    },
+    "node_modules/semver": {
+      "version": "6.3.1",
+      "resolved": "https://registry.npmjs.org/semver/-/semver-6.3.1.tgz",
+      "integrity": "sha512-BR7VvDCVHO+q2xBEWskxS6DJE1qRnb7DxzUrogb71CWoSficBxYsiAGd+Kl0mmq/MprG9yArRkyrQxTO6XjMzA==",
+      "bin": {
+        "semver": "bin/semver.js"
+      }
+    },
+    "node_modules/source-map-js": {
+      "version": "1.2.1",
+      "resolved": "https://registry.npmjs.org/source-map-js/-/source-map-js-1.2.1.tgz",
+      "integrity": "sha512-UXWMKhLOwVKb728IUtQPXxfYU+usdybtUrK/8uGE8CQMvrhOpwvzDBwj0QhSL7MQc7vIsISBG8VQ8+IDQxpfQA==",
+      "engines": {
+        "node": ">=0.10.0"
+      }
+    },
+    "node_modules/typescript": {
+      "version": "5.6.3",
+      "resolved": "https://registry.npmjs.org/typescript/-/typescript-5.6.3.tgz",
+      "integrity": "sha512-hjcS1mhfuyi4WW8IWtjP7brDrG2cuDZukyrYrSauoXGNgx0S7zceP07adYkJycEr56BOUTNPzbInooiN3fn1qw==",
+      "bin": {
+        "tsc": "bin/tsc",
+        "tsserver": "bin/tsserver"
+      },
+      "engines": {
+        "node": ">=14.17"
+      }
+    },
+    "node_modules/update-browserslist-db": {
+      "version": "1.2.3",
+      "resolved": "https://registry.npmjs.org/update-browserslist-db/-/update-browserslist-db-1.2.3.tgz",
+      "integrity": "sha512-Js0m9cx+qOgDxo0eMiFGEueWztz+d4+M3rGlmKPT+T4IS/jP4ylw3Nwpu6cpTTP8R1MAC1kF4VbdLt3ARf209w==",
+      "funding": [
+        {
+          "type": "opencollective",
+          "url": "https://opencollective.com/browserslist"
+        },
+        {
+          "type": "tidelift",
+          "url": "https://tidelift.com/funding/github/npm/browserslist"
+        },
+        {
+          "type": "github",
+          "url": "https://github.com/sponsors/ai"
+        }
+      ],
+      "dependencies": {
+        "escalade": "^3.2.0",
+        "picocolors": "^1.1.1"
+      },
+      "bin": {
+        "update-browserslist-db": "cli.js"
+      },
+      "peerDependencies": {
+        "browserslist": ">= 4.21.0"
+      }
+    },
+    "node_modules/vite": {
+      "version": "5.4.21",
+      "resolved": "https://registry.npmjs.org/vite/-/vite-5.4.21.tgz",
+      "integrity": "sha512-o5a9xKjbtuhY6Bi5S3+HvbRERmouabWbyUcpXXUA1u+GNUKoROi9byOJ8M0nHbHYHkYICiMlqxkg1KkYmm25Sw==",
+      "dependencies": {
+        "esbuild": "^0.21.3",
+        "postcss": "^8.4.43",
+        "rollup": "^4.20.0"
+      },
+      "bin": {
+        "vite": "bin/vite.js"
+      },
+      "engines": {
+        "node": "^18.0.0 || >=20.0.0"
+      },
+      "funding": {
+        "url": "https://github.com/vitejs/vite?sponsor=1"
+      },
+      "optionalDependencies": {
+        "fsevents": "~2.3.3"
+      },
+      "peerDependencies": {
+        "@types/node": "^18.0.0 || >=20.0.0",
+        "less": "*",
+        "lightningcss": "^1.21.0",
+        "sass": "*",
+        "sass-embedded": "*",
+        "stylus": "*",
+        "sugarss": "*",
+        "terser": "^5.4.0"
+      },
+      "peerDependenciesMeta": {
+        "@types/node": {
+          "optional": true
+        },
+        "less": {
+          "optional": true
+        },
+        "lightningcss": {
+          "optional": true
+        },
+        "sass": {
+          "optional": true
+        },
+        "sass-embedded": {
+          "optional": true
+        },
+        "stylus": {
+          "optional": true
+        },
+        "sugarss": {
+          "optional": true
+        },
+        "terser": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/yallist": {
+      "version": "3.1.1",
+      "resolved": "https://registry.npmjs.org/yallist/-/yallist-3.1.1.tgz",
+      "integrity": "sha512-a4UGQaWPH59mOXUYnAG2ewncQS4i4F43Tv3JoAM+s2VDAmS9NsK8GpDMLrCHPksFT7h3K6TOoUNn2pb7RoXx4g=="
+    }
+  }
+}

--- a/frontend/package.json
+++ b/frontend/package.json
@@ -1,0 +1,16 @@
+{
+  "scripts": {
+    "build": "vite build"
+  },
+  "dependencies": {
+    "@vitejs/plugin-react": "4.3.4",
+    "typescript": "5.6.3",
+    "vite": "5.4.21",
+    "react": "18.3.1",
+    "react-dom": "18.3.1"
+  },
+  "devDependencies": {
+    "@types/react": "18.3.12",
+    "@types/react-dom": "18.3.1"
+  }
+}

--- a/frontend/src/App.tsx
+++ b/frontend/src/App.tsx
@@ -1,0 +1,3 @@
+export default function App() {
+  return <h1>React OK</h1>;
+}

--- a/frontend/src/main.tsx
+++ b/frontend/src/main.tsx
@@ -1,0 +1,9 @@
+import React from 'react';
+import ReactDOM from 'react-dom/client';
+import App from './App';
+
+ReactDOM.createRoot(document.getElementById('root') as HTMLElement).render(
+  <React.StrictMode>
+    <App />
+  </React.StrictMode>,
+);

--- a/frontend/tsconfig.json
+++ b/frontend/tsconfig.json
@@ -1,0 +1,21 @@
+{
+  "compilerOptions": {
+    "target": "ES2020",
+    "useDefineForClassFields": true,
+    "lib": ["DOM", "DOM.Iterable", "ES2020"],
+    "allowJs": false,
+    "skipLibCheck": true,
+    "esModuleInterop": true,
+    "allowSyntheticDefaultImports": true,
+    "strict": true,
+    "forceConsistentCasingInFileNames": true,
+    "module": "ESNext",
+    "moduleResolution": "Node",
+    "resolveJsonModule": true,
+    "isolatedModules": true,
+    "noEmit": true,
+    "jsx": "react-jsx"
+  },
+  "include": ["src"],
+  "references": []
+}

--- a/frontend/vite.config.ts
+++ b/frontend/vite.config.ts
@@ -1,0 +1,10 @@
+import { defineConfig } from 'vite';
+import react from '@vitejs/plugin-react';
+
+export default defineConfig({
+  base: '/',
+  plugins: [react()],
+  build: {
+    outDir: 'dist',
+  },
+});

--- a/src/main/java/com/example/board/BoardApplication.java
+++ b/src/main/java/com/example/board/BoardApplication.java
@@ -8,7 +8,7 @@ import org.springframework.data.jpa.repository.config.EnableJpaAuditing;
 @EnableJpaAuditing
 public class BoardApplication {
 
-    public static void main(String[] args) {
-        SpringApplication.run(BoardApplication.class, args);
-    }
+  public static void main(String[] args) {
+    SpringApplication.run(BoardApplication.class, args);
+  }
 }

--- a/src/main/java/com/example/board/common/BaseEntity.java
+++ b/src/main/java/com/example/board/common/BaseEntity.java
@@ -12,19 +12,19 @@ import org.springframework.data.jpa.domain.support.AuditingEntityListener;
 @EntityListeners(AuditingEntityListener.class)
 public abstract class BaseEntity {
 
-    @CreatedDate
-    @Column(nullable = false, updatable = false)
-    protected Instant createdAt;
+  @CreatedDate
+  @Column(nullable = false, updatable = false)
+  protected Instant createdAt;
 
-    @LastModifiedDate
-    @Column(nullable = false)
-    protected Instant updatedAt;
+  @LastModifiedDate
+  @Column(nullable = false)
+  protected Instant updatedAt;
 
-    public Instant getCreatedAt() {
-        return createdAt;
-    }
+  public Instant getCreatedAt() {
+    return createdAt;
+  }
 
-    public Instant getUpdatedAt() {
-        return updatedAt;
-    }
+  public Instant getUpdatedAt() {
+    return updatedAt;
+  }
 }

--- a/src/main/java/com/example/board/common/ErrorResponse.java
+++ b/src/main/java/com/example/board/common/ErrorResponse.java
@@ -4,13 +4,10 @@ import java.time.Instant;
 import org.springframework.http.HttpStatus;
 
 public record ErrorResponse(
-        int status,
-        String error,
-        String message,
-        String path,
-        Instant timestamp) {
+    int status, String error, String message, String path, Instant timestamp) {
 
-    public static ErrorResponse of(HttpStatus status, String message, String path) {
-        return new ErrorResponse(status.value(), status.getReasonPhrase(), message, path, Instant.now());
-    }
+  public static ErrorResponse of(HttpStatus status, String message, String path) {
+    return new ErrorResponse(
+        status.value(), status.getReasonPhrase(), message, path, Instant.now());
+  }
 }

--- a/src/main/java/com/example/board/common/GlobalExceptionHandler.java
+++ b/src/main/java/com/example/board/common/GlobalExceptionHandler.java
@@ -14,62 +14,70 @@ import org.springframework.web.bind.annotation.ExceptionHandler;
 import org.springframework.web.bind.annotation.RestControllerAdvice;
 import org.springframework.web.server.ResponseStatusException;
 import org.springframework.web.servlet.NoHandlerFoundException;
+import org.springframework.web.servlet.resource.NoResourceFoundException;
 
 @RestControllerAdvice
 public class GlobalExceptionHandler {
 
-    private static final Logger log = LoggerFactory.getLogger(GlobalExceptionHandler.class);
+  private static final Logger log = LoggerFactory.getLogger(GlobalExceptionHandler.class);
 
-    @ExceptionHandler(MethodArgumentNotValidException.class)
-    public ResponseEntity<ErrorResponse> handleValidation(
-            MethodArgumentNotValidException ex, HttpServletRequest request) {
-        String message = ex.getBindingResult().getFieldErrors().stream()
-                .map(fieldError -> fieldError.getField() + ": " + fieldError.getDefaultMessage())
-                .collect(Collectors.joining(", "));
-        return respond(HttpStatus.BAD_REQUEST, message.isEmpty() ? "검증에 실패했습니다" : message, request);
-    }
+  @ExceptionHandler(MethodArgumentNotValidException.class)
+  public ResponseEntity<ErrorResponse> handleValidation(
+      MethodArgumentNotValidException ex, HttpServletRequest request) {
+    String message =
+        ex.getBindingResult().getFieldErrors().stream()
+            .map(fieldError -> fieldError.getField() + ": " + fieldError.getDefaultMessage())
+            .collect(Collectors.joining(", "));
+    return respond(HttpStatus.BAD_REQUEST, message.isEmpty() ? "검증에 실패했습니다" : message, request);
+  }
 
-    @ExceptionHandler(NoHandlerFoundException.class)
-    public ResponseEntity<ErrorResponse> handleNotFound(
-            NoHandlerFoundException ex, HttpServletRequest request) {
-        return respond(HttpStatus.NOT_FOUND, "요청한 리소스를 찾을 수 없습니다", request);
-    }
+  @ExceptionHandler(NoHandlerFoundException.class)
+  public ResponseEntity<ErrorResponse> handleNotFound(
+      NoHandlerFoundException ex, HttpServletRequest request) {
+    return respond(HttpStatus.NOT_FOUND, "요청한 리소스를 찾을 수 없습니다", request);
+  }
 
-    @ExceptionHandler(ResponseStatusException.class)
-    public ResponseEntity<ErrorResponse> handleResponseStatus(
-            ResponseStatusException ex, HttpServletRequest request) {
-        HttpStatus status = HttpStatus.valueOf(ex.getStatusCode().value());
-        String message = ex.getReason() != null ? ex.getReason() : status.getReasonPhrase();
-        return respond(status, message, request);
-    }
+  @ExceptionHandler(NoResourceFoundException.class)
+  public ResponseEntity<ErrorResponse> handleNoResourceFound(
+      NoResourceFoundException ex, HttpServletRequest request) {
+    return respond(HttpStatus.NOT_FOUND, "요청한 리소스를 찾을 수 없습니다", request);
+  }
 
-    @ExceptionHandler(AccessDeniedException.class)
-    public ResponseEntity<ErrorResponse> handleAccessDenied(
-            AccessDeniedException ex, HttpServletRequest request) {
-        return respond(HttpStatus.FORBIDDEN, "접근이 거부되었습니다", request);
-    }
+  @ExceptionHandler(ResponseStatusException.class)
+  public ResponseEntity<ErrorResponse> handleResponseStatus(
+      ResponseStatusException ex, HttpServletRequest request) {
+    HttpStatus status = HttpStatus.valueOf(ex.getStatusCode().value());
+    String message = ex.getReason() != null ? ex.getReason() : status.getReasonPhrase();
+    return respond(status, message, request);
+  }
 
-    @ExceptionHandler(AuthenticationException.class)
-    public ResponseEntity<ErrorResponse> handleAuthentication(
-            AuthenticationException ex, HttpServletRequest request) {
-        return respond(HttpStatus.UNAUTHORIZED, AuthErrorMessages.INVALID_CREDENTIALS, request);
-    }
+  @ExceptionHandler(AccessDeniedException.class)
+  public ResponseEntity<ErrorResponse> handleAccessDenied(
+      AccessDeniedException ex, HttpServletRequest request) {
+    return respond(HttpStatus.FORBIDDEN, "접근이 거부되었습니다", request);
+  }
 
-    @ExceptionHandler(IllegalArgumentException.class)
-    public ResponseEntity<ErrorResponse> handleIllegal(
-            IllegalArgumentException ex, HttpServletRequest request) {
-        return respond(HttpStatus.BAD_REQUEST, ex.getMessage(), request);
-    }
+  @ExceptionHandler(AuthenticationException.class)
+  public ResponseEntity<ErrorResponse> handleAuthentication(
+      AuthenticationException ex, HttpServletRequest request) {
+    return respond(HttpStatus.UNAUTHORIZED, AuthErrorMessages.INVALID_CREDENTIALS, request);
+  }
 
-    @ExceptionHandler(Exception.class)
-    public ResponseEntity<ErrorResponse> handleAll(Exception ex, HttpServletRequest request) {
-        log.error("처리되지 않은 예외 발생: {}", ex.getClass().getSimpleName(), ex);
-        return respond(HttpStatus.INTERNAL_SERVER_ERROR, "서버 오류가 발생했습니다", request);
-    }
+  @ExceptionHandler(IllegalArgumentException.class)
+  public ResponseEntity<ErrorResponse> handleIllegal(
+      IllegalArgumentException ex, HttpServletRequest request) {
+    return respond(HttpStatus.BAD_REQUEST, ex.getMessage(), request);
+  }
 
-    private ResponseEntity<ErrorResponse> respond(
-            HttpStatus status, String message, HttpServletRequest request) {
-        return ResponseEntity.status(status)
-                .body(ErrorResponse.of(status, message, request.getRequestURI()));
-    }
+  @ExceptionHandler(Exception.class)
+  public ResponseEntity<ErrorResponse> handleAll(Exception ex, HttpServletRequest request) {
+    log.error("처리되지 않은 예외 발생: {}", ex.getClass().getSimpleName(), ex);
+    return respond(HttpStatus.INTERNAL_SERVER_ERROR, "서버 오류가 발생했습니다", request);
+  }
+
+  private ResponseEntity<ErrorResponse> respond(
+      HttpStatus status, String message, HttpServletRequest request) {
+    return ResponseEntity.status(status)
+        .body(ErrorResponse.of(status, message, request.getRequestURI()));
+  }
 }

--- a/src/main/java/com/example/board/config/RestAccessDeniedHandler.java
+++ b/src/main/java/com/example/board/config/RestAccessDeniedHandler.java
@@ -14,22 +14,23 @@ import org.springframework.stereotype.Component;
 @Component
 public class RestAccessDeniedHandler implements AccessDeniedHandler {
 
-    private final ObjectMapper objectMapper;
+  private final ObjectMapper objectMapper;
 
-    public RestAccessDeniedHandler(ObjectMapper objectMapper) {
-        this.objectMapper = objectMapper;
-    }
+  public RestAccessDeniedHandler(ObjectMapper objectMapper) {
+    this.objectMapper = objectMapper;
+  }
 
-    @Override
-    public void handle(
-            HttpServletRequest request,
-            HttpServletResponse response,
-            AccessDeniedException accessDeniedException) throws IOException {
-        response.setStatus(HttpStatus.FORBIDDEN.value());
-        response.setContentType(MediaType.APPLICATION_JSON_VALUE);
-        response.setCharacterEncoding("UTF-8");
-        ErrorResponse body = ErrorResponse.of(
-                HttpStatus.FORBIDDEN, "접근이 거부되었습니다", request.getRequestURI());
-        objectMapper.writeValue(response.getWriter(), body);
-    }
+  @Override
+  public void handle(
+      HttpServletRequest request,
+      HttpServletResponse response,
+      AccessDeniedException accessDeniedException)
+      throws IOException {
+    response.setStatus(HttpStatus.FORBIDDEN.value());
+    response.setContentType(MediaType.APPLICATION_JSON_VALUE);
+    response.setCharacterEncoding("UTF-8");
+    ErrorResponse body =
+        ErrorResponse.of(HttpStatus.FORBIDDEN, "접근이 거부되었습니다", request.getRequestURI());
+    objectMapper.writeValue(response.getWriter(), body);
+  }
 }

--- a/src/main/java/com/example/board/config/RestAuthenticationEntryPoint.java
+++ b/src/main/java/com/example/board/config/RestAuthenticationEntryPoint.java
@@ -14,22 +14,23 @@ import org.springframework.stereotype.Component;
 @Component
 public class RestAuthenticationEntryPoint implements AuthenticationEntryPoint {
 
-    private final ObjectMapper objectMapper;
+  private final ObjectMapper objectMapper;
 
-    public RestAuthenticationEntryPoint(ObjectMapper objectMapper) {
-        this.objectMapper = objectMapper;
-    }
+  public RestAuthenticationEntryPoint(ObjectMapper objectMapper) {
+    this.objectMapper = objectMapper;
+  }
 
-    @Override
-    public void commence(
-            HttpServletRequest request,
-            HttpServletResponse response,
-            AuthenticationException authException) throws IOException {
-        response.setStatus(HttpStatus.UNAUTHORIZED.value());
-        response.setContentType(MediaType.APPLICATION_JSON_VALUE);
-        response.setCharacterEncoding("UTF-8");
-        ErrorResponse body = ErrorResponse.of(
-                HttpStatus.UNAUTHORIZED, "인증이 필요합니다", request.getRequestURI());
-        objectMapper.writeValue(response.getWriter(), body);
-    }
+  @Override
+  public void commence(
+      HttpServletRequest request,
+      HttpServletResponse response,
+      AuthenticationException authException)
+      throws IOException {
+    response.setStatus(HttpStatus.UNAUTHORIZED.value());
+    response.setContentType(MediaType.APPLICATION_JSON_VALUE);
+    response.setCharacterEncoding("UTF-8");
+    ErrorResponse body =
+        ErrorResponse.of(HttpStatus.UNAUTHORIZED, "인증이 필요합니다", request.getRequestURI());
+    objectMapper.writeValue(response.getWriter(), body);
+  }
 }

--- a/src/main/java/com/example/board/config/SecurityConfig.java
+++ b/src/main/java/com/example/board/config/SecurityConfig.java
@@ -14,52 +14,70 @@ import org.springframework.security.crypto.password.PasswordEncoder;
 import org.springframework.security.web.SecurityFilterChain;
 import org.springframework.security.web.authentication.UsernamePasswordAuthenticationFilter;
 import org.springframework.security.web.util.matcher.AntPathRequestMatcher;
+import org.springframework.security.web.util.matcher.RegexRequestMatcher;
 
 @Configuration
 public class SecurityConfig {
 
-    private final RestAuthenticationEntryPoint authenticationEntryPoint;
-    private final RestAccessDeniedHandler accessDeniedHandler;
-    private final JwtAuthenticationFilter jwtAuthenticationFilter;
+  private final RestAuthenticationEntryPoint authenticationEntryPoint;
+  private final RestAccessDeniedHandler accessDeniedHandler;
+  private final JwtAuthenticationFilter jwtAuthenticationFilter;
 
-    public SecurityConfig(
-            RestAuthenticationEntryPoint authenticationEntryPoint,
-            RestAccessDeniedHandler accessDeniedHandler,
-            JwtAuthenticationFilter jwtAuthenticationFilter) {
-        this.authenticationEntryPoint = authenticationEntryPoint;
-        this.accessDeniedHandler = accessDeniedHandler;
-        this.jwtAuthenticationFilter = jwtAuthenticationFilter;
-    }
+  public SecurityConfig(
+      RestAuthenticationEntryPoint authenticationEntryPoint,
+      RestAccessDeniedHandler accessDeniedHandler,
+      JwtAuthenticationFilter jwtAuthenticationFilter) {
+    this.authenticationEntryPoint = authenticationEntryPoint;
+    this.accessDeniedHandler = accessDeniedHandler;
+    this.jwtAuthenticationFilter = jwtAuthenticationFilter;
+  }
 
-    @Bean
-    public PasswordEncoder passwordEncoder() {
-        return new BCryptPasswordEncoder();
-    }
+  @Bean
+  public PasswordEncoder passwordEncoder() {
+    return new BCryptPasswordEncoder();
+  }
 
-    @Bean
-    public AuthenticationManager authenticationManager(AuthenticationConfiguration configuration) throws Exception {
-        return configuration.getAuthenticationManager();
-    }
+  @Bean
+  public AuthenticationManager authenticationManager(AuthenticationConfiguration configuration)
+      throws Exception {
+    return configuration.getAuthenticationManager();
+  }
 
-    @Bean
-    public SecurityFilterChain filterChain(HttpSecurity http) throws Exception {
-        http
-                .csrf(csrf -> csrf.disable())
-                .sessionManagement(session -> session.sessionCreationPolicy(SessionCreationPolicy.STATELESS))
-                .headers(headers -> headers.frameOptions(HeadersConfigurer.FrameOptionsConfig::sameOrigin))
-                .authorizeHttpRequests(auth -> auth
-                        .requestMatchers(AntPathRequestMatcher.antMatcher("/h2-console/**")).permitAll()
-                        .requestMatchers(AntPathRequestMatcher.antMatcher("/api/auth/**")).permitAll()
-                        .requestMatchers(AntPathRequestMatcher.antMatcher("/signup")).permitAll()
-                        .requestMatchers(AntPathRequestMatcher.antMatcher("/login")).permitAll()
-                        .requestMatchers(AntPathRequestMatcher.antMatcher("/css/**")).permitAll()
-                        .requestMatchers(AntPathRequestMatcher.antMatcher("/webjars/**")).permitAll()
-                        .requestMatchers(HttpMethod.GET, "/api/posts", "/api/posts/*").permitAll()
-                        .anyRequest().authenticated())
-                .exceptionHandling(ex -> ex
-                        .authenticationEntryPoint(authenticationEntryPoint)
-                        .accessDeniedHandler(accessDeniedHandler))
-                .addFilterBefore(jwtAuthenticationFilter, UsernamePasswordAuthenticationFilter.class);
-        return http.build();
-    }
+  @Bean
+  public SecurityFilterChain filterChain(HttpSecurity http) throws Exception {
+    http.csrf(csrf -> csrf.disable())
+        .sessionManagement(
+            session -> session.sessionCreationPolicy(SessionCreationPolicy.STATELESS))
+        .headers(headers -> headers.frameOptions(HeadersConfigurer.FrameOptionsConfig::sameOrigin))
+        .authorizeHttpRequests(
+            auth ->
+                auth.requestMatchers(AntPathRequestMatcher.antMatcher("/h2-console/**"))
+                    .permitAll()
+                    .requestMatchers(AntPathRequestMatcher.antMatcher("/api/auth/**"))
+                    .permitAll()
+                    .requestMatchers(AntPathRequestMatcher.antMatcher("/signup"))
+                    .permitAll()
+                    .requestMatchers(AntPathRequestMatcher.antMatcher("/login"))
+                    .permitAll()
+                    .requestMatchers(AntPathRequestMatcher.antMatcher("/css/**"))
+                    .permitAll()
+                    .requestMatchers(AntPathRequestMatcher.antMatcher("/webjars/**"))
+                    .permitAll()
+                    .requestMatchers(HttpMethod.GET, "/api/posts", "/api/posts/*")
+                    .permitAll()
+                    .requestMatchers(HttpMethod.GET, "/", "/index.html", "/assets/**")
+                    .permitAll()
+                    .requestMatchers(
+                        new RegexRequestMatcher(
+                            "^(?!/api(?:/|$))(?!/h2-console(?:/|$))[^.]*$", HttpMethod.GET.name()))
+                    .permitAll()
+                    .anyRequest()
+                    .authenticated())
+        .exceptionHandling(
+            ex ->
+                ex.authenticationEntryPoint(authenticationEntryPoint)
+                    .accessDeniedHandler(accessDeniedHandler))
+        .addFilterBefore(jwtAuthenticationFilter, UsernamePasswordAuthenticationFilter.class);
+    return http.build();
+  }
 }

--- a/src/main/java/com/example/board/config/WebMvcConfig.java
+++ b/src/main/java/com/example/board/config/WebMvcConfig.java
@@ -1,0 +1,28 @@
+package com.example.board.config;
+
+import org.springframework.context.annotation.Configuration;
+import org.springframework.web.servlet.config.annotation.ResourceHandlerRegistry;
+import org.springframework.web.servlet.config.annotation.ViewControllerRegistry;
+import org.springframework.web.servlet.config.annotation.WebMvcConfigurer;
+
+@Configuration
+public class WebMvcConfig implements WebMvcConfigurer {
+
+  @Override
+  public void addViewControllers(ViewControllerRegistry registry) {
+    registry.addViewController("/").setViewName("forward:/index.html");
+    registry
+        .addViewController("/{path:^(?!api|h2-console|assets)[^.]*}")
+        .setViewName("forward:/index.html");
+    registry
+        .addViewController("/{path:^(?!api|h2-console|assets)[^.]*}/**")
+        .setViewName("forward:/index.html");
+  }
+
+  @Override
+  public void addResourceHandlers(ResourceHandlerRegistry registry) {
+    registry
+        .addResourceHandler("/index.html", "/assets/**")
+        .addResourceLocations("classpath:/static/");
+  }
+}

--- a/src/main/java/com/example/board/post/Post.java
+++ b/src/main/java/com/example/board/post/Post.java
@@ -17,52 +17,51 @@ import jakarta.persistence.Table;
 @Table(name = "posts")
 public class Post extends BaseEntity {
 
-    @Id
-    @GeneratedValue(strategy = GenerationType.IDENTITY)
-    private Long id;
+  @Id
+  @GeneratedValue(strategy = GenerationType.IDENTITY)
+  private Long id;
 
-    @Column(nullable = false, length = 100)
-    private String title;
+  @Column(nullable = false, length = 100)
+  private String title;
 
-    @Lob
-    @Column(nullable = false)
-    private String content;
+  @Lob
+  @Column(nullable = false)
+  private String content;
 
-    @ManyToOne(fetch = FetchType.LAZY, optional = false)
-    @JoinColumn(name = "author_id", nullable = false)
-    private User author;
+  @ManyToOne(fetch = FetchType.LAZY, optional = false)
+  @JoinColumn(name = "author_id", nullable = false)
+  private User author;
 
-    protected Post() {
-    }
+  protected Post() {}
 
-    public Post(String title, String content, User author) {
-        this.title = title;
-        this.content = content;
-        this.author = author;
-    }
+  public Post(String title, String content, User author) {
+    this.title = title;
+    this.content = content;
+    this.author = author;
+  }
 
-    public void update(String title, String content) {
-        this.title = title;
-        this.content = content;
-    }
+  public void update(String title, String content) {
+    this.title = title;
+    this.content = content;
+  }
 
-    public boolean isOwnedBy(String username) {
-        return author != null && author.getUsername().equals(username);
-    }
+  public boolean isOwnedBy(String username) {
+    return author != null && author.getUsername().equals(username);
+  }
 
-    public Long getId() {
-        return id;
-    }
+  public Long getId() {
+    return id;
+  }
 
-    public String getTitle() {
-        return title;
-    }
+  public String getTitle() {
+    return title;
+  }
 
-    public String getContent() {
-        return content;
-    }
+  public String getContent() {
+    return content;
+  }
 
-    public User getAuthor() {
-        return author;
-    }
+  public User getAuthor() {
+    return author;
+  }
 }

--- a/src/main/java/com/example/board/post/PostController.java
+++ b/src/main/java/com/example/board/post/PostController.java
@@ -19,51 +19,50 @@ import org.springframework.web.bind.annotation.RestController;
 @RequestMapping("/api/posts")
 public class PostController {
 
-    private final PostService postService;
+  private final PostService postService;
 
-    public PostController(PostService postService) {
-        this.postService = postService;
-    }
+  public PostController(PostService postService) {
+    this.postService = postService;
+  }
 
-    @GetMapping
-    public PostResponse.PageResponse<PostResponse> list(
-            @RequestParam(defaultValue = "0") int page,
-            @RequestParam(defaultValue = "10") int size) {
-        if (page < 0) {
-            throw new IllegalArgumentException("page는 0 이상이어야 합니다");
-        }
-        if (size <= 0) {
-            throw new IllegalArgumentException("size는 1 이상이어야 합니다");
-        }
-        return PostResponse.PageResponse.from(
-                postService.list(PageRequest.of(page, size)).map(PostResponse::from));
+  @GetMapping
+  public PostResponse.PageResponse<PostResponse> list(
+      @RequestParam(defaultValue = "0") int page, @RequestParam(defaultValue = "10") int size) {
+    if (page < 0) {
+      throw new IllegalArgumentException("page는 0 이상이어야 합니다");
     }
+    if (size <= 0) {
+      throw new IllegalArgumentException("size는 1 이상이어야 합니다");
+    }
+    return PostResponse.PageResponse.from(
+        postService.list(PageRequest.of(page, size)).map(PostResponse::from));
+  }
 
-    @GetMapping("/{id}")
-    public PostResponse get(@PathVariable Long id) {
-        return PostResponse.from(postService.get(id));
-    }
+  @GetMapping("/{id}")
+  public PostResponse get(@PathVariable Long id) {
+    return PostResponse.from(postService.get(id));
+  }
 
-    @PostMapping
-    @ResponseStatus(HttpStatus.CREATED)
-    public PostResponse create(
-            @Valid @RequestBody PostWriteRequest.Create request, Authentication authentication) {
-        return PostResponse.from(
-                postService.create(request.title(), request.content(), authentication.getName()));
-    }
+  @PostMapping
+  @ResponseStatus(HttpStatus.CREATED)
+  public PostResponse create(
+      @Valid @RequestBody PostWriteRequest.Create request, Authentication authentication) {
+    return PostResponse.from(
+        postService.create(request.title(), request.content(), authentication.getName()));
+  }
 
-    @PutMapping("/{id}")
-    public PostResponse update(
-            @PathVariable Long id,
-            @Valid @RequestBody PostWriteRequest.Update request,
-            Authentication authentication) {
-        return PostResponse.from(
-                postService.update(id, request.title(), request.content(), authentication.getName()));
-    }
+  @PutMapping("/{id}")
+  public PostResponse update(
+      @PathVariable Long id,
+      @Valid @RequestBody PostWriteRequest.Update request,
+      Authentication authentication) {
+    return PostResponse.from(
+        postService.update(id, request.title(), request.content(), authentication.getName()));
+  }
 
-    @DeleteMapping("/{id}")
-    @ResponseStatus(HttpStatus.NO_CONTENT)
-    public void delete(@PathVariable Long id, Authentication authentication) {
-        postService.delete(id, authentication.getName());
-    }
+  @DeleteMapping("/{id}")
+  @ResponseStatus(HttpStatus.NO_CONTENT)
+  public void delete(@PathVariable Long id, Authentication authentication) {
+    postService.delete(id, authentication.getName());
+  }
 }

--- a/src/main/java/com/example/board/post/PostRepository.java
+++ b/src/main/java/com/example/board/post/PostRepository.java
@@ -8,10 +8,10 @@ import org.springframework.data.jpa.repository.JpaRepository;
 
 public interface PostRepository extends JpaRepository<Post, Long> {
 
-    @EntityGraph(attributePaths = "author")
-    Page<Post> findAllByOrderByCreatedAtDesc(Pageable pageable);
+  @EntityGraph(attributePaths = "author")
+  Page<Post> findAllByOrderByCreatedAtDesc(Pageable pageable);
 
-    @Override
-    @EntityGraph(attributePaths = "author")
-    Optional<Post> findById(Long id);
+  @Override
+  @EntityGraph(attributePaths = "author")
+  Optional<Post> findById(Long id);
 }

--- a/src/main/java/com/example/board/post/PostResponse.java
+++ b/src/main/java/com/example/board/post/PostResponse.java
@@ -5,37 +5,33 @@ import java.util.List;
 import org.springframework.data.domain.Page;
 
 public record PostResponse(
-        Long id,
-        String title,
-        String content,
-        String authorUsername,
-        Instant createdAt,
-        Instant updatedAt) {
+    Long id,
+    String title,
+    String content,
+    String authorUsername,
+    Instant createdAt,
+    Instant updatedAt) {
 
-    public static PostResponse from(Post post) {
-        return new PostResponse(
-                post.getId(),
-                post.getTitle(),
-                post.getContent(),
-                post.getAuthor().getUsername(),
-                post.getCreatedAt(),
-                post.getUpdatedAt());
+  public static PostResponse from(Post post) {
+    return new PostResponse(
+        post.getId(),
+        post.getTitle(),
+        post.getContent(),
+        post.getAuthor().getUsername(),
+        post.getCreatedAt(),
+        post.getUpdatedAt());
+  }
+
+  public record PageResponse<T>(
+      List<T> content, int page, int size, long totalElements, int totalPages) {
+
+    public static <T> PageResponse<T> from(Page<T> page) {
+      return new PageResponse<>(
+          page.getContent(),
+          page.getNumber(),
+          page.getSize(),
+          page.getTotalElements(),
+          page.getTotalPages());
     }
-
-    public record PageResponse<T>(
-            List<T> content,
-            int page,
-            int size,
-            long totalElements,
-            int totalPages) {
-
-        public static <T> PageResponse<T> from(Page<T> page) {
-            return new PageResponse<>(
-                    page.getContent(),
-                    page.getNumber(),
-                    page.getSize(),
-                    page.getTotalElements(),
-                    page.getTotalPages());
-        }
-    }
+  }
 }

--- a/src/main/java/com/example/board/post/PostService.java
+++ b/src/main/java/com/example/board/post/PostService.java
@@ -14,49 +14,54 @@ import org.springframework.web.server.ResponseStatusException;
 @Transactional
 public class PostService {
 
-    private final PostRepository postRepository;
-    private final UserRepository userRepository;
+  private final PostRepository postRepository;
+  private final UserRepository userRepository;
 
-    public PostService(PostRepository postRepository, UserRepository userRepository) {
-        this.postRepository = postRepository;
-        this.userRepository = userRepository;
-    }
+  public PostService(PostRepository postRepository, UserRepository userRepository) {
+    this.postRepository = postRepository;
+    this.userRepository = userRepository;
+  }
 
-    @Transactional(readOnly = true)
-    public Page<Post> list(Pageable pageable) {
-        return postRepository.findAllByOrderByCreatedAtDesc(pageable);
-    }
+  @Transactional(readOnly = true)
+  public Page<Post> list(Pageable pageable) {
+    return postRepository.findAllByOrderByCreatedAtDesc(pageable);
+  }
 
-    @Transactional(readOnly = true)
-    public Post get(Long id) {
-        return postRepository.findById(id)
-                .orElseThrow(() -> new ResponseStatusException(
-                        HttpStatus.NOT_FOUND, "게시글을 찾을 수 없습니다: " + id));
-    }
+  @Transactional(readOnly = true)
+  public Post get(Long id) {
+    return postRepository
+        .findById(id)
+        .orElseThrow(
+            () -> new ResponseStatusException(HttpStatus.NOT_FOUND, "게시글을 찾을 수 없습니다: " + id));
+  }
 
-    public Post create(String title, String content, String username) {
-        User author = userRepository.findByUsername(username)
-                .orElseThrow(() -> new ResponseStatusException(
+  public Post create(String title, String content, String username) {
+    User author =
+        userRepository
+            .findByUsername(username)
+            .orElseThrow(
+                () ->
+                    new ResponseStatusException(
                         HttpStatus.NOT_FOUND, "사용자를 찾을 수 없습니다: " + username));
-        return postRepository.save(new Post(title, content, author));
-    }
+    return postRepository.save(new Post(title, content, author));
+  }
 
-    public Post update(Long id, String title, String content, String username) {
-        Post post = get(id);
-        assertOwnedBy(post, username);
-        post.update(title, content);
-        return post;
-    }
+  public Post update(Long id, String title, String content, String username) {
+    Post post = get(id);
+    assertOwnedBy(post, username);
+    post.update(title, content);
+    return post;
+  }
 
-    public void delete(Long id, String username) {
-        Post post = get(id);
-        assertOwnedBy(post, username);
-        postRepository.delete(post);
-    }
+  public void delete(Long id, String username) {
+    Post post = get(id);
+    assertOwnedBy(post, username);
+    postRepository.delete(post);
+  }
 
-    private void assertOwnedBy(Post post, String username) {
-        if (!post.isOwnedBy(username)) {
-            throw new AccessDeniedException("본인의 글만 수정/삭제할 수 있습니다");
-        }
+  private void assertOwnedBy(Post post, String username) {
+    if (!post.isOwnedBy(username)) {
+      throw new AccessDeniedException("본인의 글만 수정/삭제할 수 있습니다");
     }
+  }
 }

--- a/src/main/java/com/example/board/post/PostWriteRequest.java
+++ b/src/main/java/com/example/board/post/PostWriteRequest.java
@@ -5,24 +5,15 @@ import jakarta.validation.constraints.Size;
 
 public final class PostWriteRequest {
 
-    private PostWriteRequest() {
-    }
+  private PostWriteRequest() {}
 
-    public record Create(
-            @NotBlank(message = "title은 필수입니다")
-            @Size(max = 100, message = "title은 최대 100자입니다")
-            String title,
+  public record Create(
+      @NotBlank(message = "title은 필수입니다") @Size(max = 100, message = "title은 최대 100자입니다")
+          String title,
+      @NotBlank(message = "content는 필수입니다") String content) {}
 
-            @NotBlank(message = "content는 필수입니다")
-            String content) {
-    }
-
-    public record Update(
-            @NotBlank(message = "title은 필수입니다")
-            @Size(max = 100, message = "title은 최대 100자입니다")
-            String title,
-
-            @NotBlank(message = "content는 필수입니다")
-            String content) {
-    }
+  public record Update(
+      @NotBlank(message = "title은 필수입니다") @Size(max = 100, message = "title은 최대 100자입니다")
+          String title,
+      @NotBlank(message = "content는 필수입니다") String content) {}
 }

--- a/src/main/java/com/example/board/security/CustomUserDetailsService.java
+++ b/src/main/java/com/example/board/security/CustomUserDetailsService.java
@@ -11,20 +11,22 @@ import org.springframework.stereotype.Service;
 @Service
 public class CustomUserDetailsService implements UserDetailsService {
 
-    private final UserRepository userRepository;
+  private final UserRepository userRepository;
 
-    public CustomUserDetailsService(UserRepository userRepository) {
-        this.userRepository = userRepository;
-    }
+  public CustomUserDetailsService(UserRepository userRepository) {
+    this.userRepository = userRepository;
+  }
 
-    @Override
-    public UserDetails loadUserByUsername(String username) throws UsernameNotFoundException {
-        User user = userRepository.findByUsername(username)
-                .orElseThrow(() -> new UsernameNotFoundException("사용자를 찾을 수 없습니다: " + username));
-        return org.springframework.security.core.userdetails.User.builder()
-                .username(user.getUsername())
-                .password(user.getPassword())
-                .authorities(Collections.emptyList())
-                .build();
-    }
+  @Override
+  public UserDetails loadUserByUsername(String username) throws UsernameNotFoundException {
+    User user =
+        userRepository
+            .findByUsername(username)
+            .orElseThrow(() -> new UsernameNotFoundException("사용자를 찾을 수 없습니다: " + username));
+    return org.springframework.security.core.userdetails.User.builder()
+        .username(user.getUsername())
+        .password(user.getPassword())
+        .authorities(Collections.emptyList())
+        .build();
+  }
 }

--- a/src/main/java/com/example/board/security/JwtAuthenticationFilter.java
+++ b/src/main/java/com/example/board/security/JwtAuthenticationFilter.java
@@ -20,40 +20,41 @@ import org.springframework.web.filter.OncePerRequestFilter;
 @Component
 public class JwtAuthenticationFilter extends OncePerRequestFilter {
 
-    private static final Logger log = LoggerFactory.getLogger(JwtAuthenticationFilter.class);
+  private static final Logger log = LoggerFactory.getLogger(JwtAuthenticationFilter.class);
 
-    private static final String HEADER = "Authorization";
-    private static final String BEARER_PREFIX = "Bearer ";
+  private static final String HEADER = "Authorization";
+  private static final String BEARER_PREFIX = "Bearer ";
 
-    private final JwtTokenProvider jwtTokenProvider;
-    private final UserDetailsService userDetailsService;
+  private final JwtTokenProvider jwtTokenProvider;
+  private final UserDetailsService userDetailsService;
 
-    public JwtAuthenticationFilter(JwtTokenProvider jwtTokenProvider, UserDetailsService userDetailsService) {
-        this.jwtTokenProvider = jwtTokenProvider;
-        this.userDetailsService = userDetailsService;
-    }
+  public JwtAuthenticationFilter(
+      JwtTokenProvider jwtTokenProvider, UserDetailsService userDetailsService) {
+    this.jwtTokenProvider = jwtTokenProvider;
+    this.userDetailsService = userDetailsService;
+  }
 
-    @Override
-    protected void doFilterInternal(
-            HttpServletRequest request, HttpServletResponse response, FilterChain chain)
-            throws ServletException, IOException {
-        String header = request.getHeader(HEADER);
-        if (header != null && header.startsWith(BEARER_PREFIX)) {
-            String token = header.substring(BEARER_PREFIX.length());
-            Optional<String> username = jwtTokenProvider.resolveUsername(token);
-            if (username.isPresent() && SecurityContextHolder.getContext().getAuthentication() == null) {
-                try {
-                    UserDetails userDetails = userDetailsService.loadUserByUsername(username.get());
-                    UsernamePasswordAuthenticationToken authentication =
-                            new UsernamePasswordAuthenticationToken(
-                                    userDetails, null, userDetails.getAuthorities());
-                    authentication.setDetails(new WebAuthenticationDetailsSource().buildDetails(request));
-                    SecurityContextHolder.getContext().setAuthentication(authentication);
-                } catch (UsernameNotFoundException ex) {
-                    log.debug("JWT 유효하지만 사용자 미존재: {}", username.get());
-                }
-            }
+  @Override
+  protected void doFilterInternal(
+      HttpServletRequest request, HttpServletResponse response, FilterChain chain)
+      throws ServletException, IOException {
+    String header = request.getHeader(HEADER);
+    if (header != null && header.startsWith(BEARER_PREFIX)) {
+      String token = header.substring(BEARER_PREFIX.length());
+      Optional<String> username = jwtTokenProvider.resolveUsername(token);
+      if (username.isPresent() && SecurityContextHolder.getContext().getAuthentication() == null) {
+        try {
+          UserDetails userDetails = userDetailsService.loadUserByUsername(username.get());
+          UsernamePasswordAuthenticationToken authentication =
+              new UsernamePasswordAuthenticationToken(
+                  userDetails, null, userDetails.getAuthorities());
+          authentication.setDetails(new WebAuthenticationDetailsSource().buildDetails(request));
+          SecurityContextHolder.getContext().setAuthentication(authentication);
+        } catch (UsernameNotFoundException ex) {
+          log.debug("JWT 유효하지만 사용자 미존재: {}", username.get());
         }
-        chain.doFilter(request, response);
+      }
     }
+    chain.doFilter(request, response);
+  }
 }

--- a/src/main/java/com/example/board/security/JwtTokenProvider.java
+++ b/src/main/java/com/example/board/security/JwtTokenProvider.java
@@ -14,41 +14,37 @@ import org.springframework.stereotype.Component;
 @Component
 public class JwtTokenProvider {
 
-    private final SecretKey key;
-    private final long expirationMs;
+  private final SecretKey key;
+  private final long expirationMs;
 
-    public JwtTokenProvider(
-            @Value("${app.jwt.secret}") String secret,
-            @Value("${app.jwt.expiration-ms}") long expirationMs) {
-        this.key = Keys.hmacShaKeyFor(secret.getBytes(StandardCharsets.UTF_8));
-        this.expirationMs = expirationMs;
-    }
+  public JwtTokenProvider(
+      @Value("${app.jwt.secret}") String secret,
+      @Value("${app.jwt.expiration-ms}") long expirationMs) {
+    this.key = Keys.hmacShaKeyFor(secret.getBytes(StandardCharsets.UTF_8));
+    this.expirationMs = expirationMs;
+  }
 
-    public String generateToken(String username) {
-        Date now = new Date();
-        Date expiry = new Date(now.getTime() + expirationMs);
-        return Jwts.builder()
-                .subject(username)
-                .issuedAt(now)
-                .expiration(expiry)
-                .signWith(key, Jwts.SIG.HS256)
-                .compact();
-    }
+  public String generateToken(String username) {
+    Date now = new Date();
+    Date expiry = new Date(now.getTime() + expirationMs);
+    return Jwts.builder()
+        .subject(username)
+        .issuedAt(now)
+        .expiration(expiry)
+        .signWith(key, Jwts.SIG.HS256)
+        .compact();
+  }
 
-    public Optional<String> resolveUsername(String token) {
-        try {
-            Claims claims = Jwts.parser()
-                    .verifyWith(key)
-                    .build()
-                    .parseSignedClaims(token)
-                    .getPayload();
-            return Optional.ofNullable(claims.getSubject());
-        } catch (JwtException | IllegalArgumentException ex) {
-            return Optional.empty();
-        }
+  public Optional<String> resolveUsername(String token) {
+    try {
+      Claims claims = Jwts.parser().verifyWith(key).build().parseSignedClaims(token).getPayload();
+      return Optional.ofNullable(claims.getSubject());
+    } catch (JwtException | IllegalArgumentException ex) {
+      return Optional.empty();
     }
+  }
 
-    public long getExpirationMs() {
-        return expirationMs;
-    }
+  public long getExpirationMs() {
+    return expirationMs;
+  }
 }

--- a/src/main/java/com/example/board/user/AuthErrorMessages.java
+++ b/src/main/java/com/example/board/user/AuthErrorMessages.java
@@ -2,8 +2,7 @@ package com.example.board.user;
 
 public final class AuthErrorMessages {
 
-    public static final String INVALID_CREDENTIALS = "username과 password가 일치하지 않습니다";
+  public static final String INVALID_CREDENTIALS = "username과 password가 일치하지 않습니다";
 
-    private AuthErrorMessages() {
-    }
+  private AuthErrorMessages() {}
 }

--- a/src/main/java/com/example/board/user/AuthRestController.java
+++ b/src/main/java/com/example/board/user/AuthRestController.java
@@ -12,24 +12,23 @@ import org.springframework.web.bind.annotation.RestController;
 @RequestMapping("/api/auth")
 public class AuthRestController {
 
-    private final AuthService authService;
+  private final AuthService authService;
 
-    public AuthRestController(AuthService authService) {
-        this.authService = authService;
-    }
+  public AuthRestController(AuthService authService) {
+    this.authService = authService;
+  }
 
-    @PostMapping("/signup")
-    public ResponseEntity<SignupResponse> signup(@Valid @RequestBody SignupRequest request) {
-        User user = authService.signup(request);
-        return ResponseEntity.status(HttpStatus.CREATED)
-                .body(new SignupResponse(user.getId(), user.getUsername()));
-    }
+  @PostMapping("/signup")
+  public ResponseEntity<SignupResponse> signup(@Valid @RequestBody SignupRequest request) {
+    User user = authService.signup(request);
+    return ResponseEntity.status(HttpStatus.CREATED)
+        .body(new SignupResponse(user.getId(), user.getUsername()));
+  }
 
-    @PostMapping("/login")
-    public ResponseEntity<TokenResponse> login(@Valid @RequestBody LoginRequest request) {
-        return ResponseEntity.ok(authService.login(request));
-    }
+  @PostMapping("/login")
+  public ResponseEntity<TokenResponse> login(@Valid @RequestBody LoginRequest request) {
+    return ResponseEntity.ok(authService.login(request));
+  }
 
-    public record SignupResponse(Long id, String username) {
-    }
+  public record SignupResponse(Long id, String username) {}
 }

--- a/src/main/java/com/example/board/user/AuthService.java
+++ b/src/main/java/com/example/board/user/AuthService.java
@@ -11,40 +11,41 @@ import org.springframework.transaction.annotation.Transactional;
 @Service
 public class AuthService {
 
-    private final UserRepository userRepository;
-    private final PasswordEncoder passwordEncoder;
-    private final AuthenticationManager authenticationManager;
-    private final JwtTokenProvider jwtTokenProvider;
+  private final UserRepository userRepository;
+  private final PasswordEncoder passwordEncoder;
+  private final AuthenticationManager authenticationManager;
+  private final JwtTokenProvider jwtTokenProvider;
 
-    public AuthService(
-            UserRepository userRepository,
-            PasswordEncoder passwordEncoder,
-            AuthenticationManager authenticationManager,
-            JwtTokenProvider jwtTokenProvider) {
-        this.userRepository = userRepository;
-        this.passwordEncoder = passwordEncoder;
-        this.authenticationManager = authenticationManager;
-        this.jwtTokenProvider = jwtTokenProvider;
-    }
+  public AuthService(
+      UserRepository userRepository,
+      PasswordEncoder passwordEncoder,
+      AuthenticationManager authenticationManager,
+      JwtTokenProvider jwtTokenProvider) {
+    this.userRepository = userRepository;
+    this.passwordEncoder = passwordEncoder;
+    this.authenticationManager = authenticationManager;
+    this.jwtTokenProvider = jwtTokenProvider;
+  }
 
-    @Transactional
-    public User signup(SignupRequest request) {
-        String username = request.getUsername() == null ? "" : request.getUsername().trim();
-        if (username.isEmpty()) {
-            throw new IllegalArgumentException("username은 필수입니다");
-        }
-        if (userRepository.existsByUsername(username)) {
-            throw new IllegalArgumentException("이미 사용 중인 username입니다: " + username);
-        }
-        String hashed = passwordEncoder.encode(request.getPassword());
-        return userRepository.save(new User(username, hashed));
+  @Transactional
+  public User signup(SignupRequest request) {
+    String username = request.getUsername() == null ? "" : request.getUsername().trim();
+    if (username.isEmpty()) {
+      throw new IllegalArgumentException("username은 필수입니다");
     }
+    if (userRepository.existsByUsername(username)) {
+      throw new IllegalArgumentException("이미 사용 중인 username입니다: " + username);
+    }
+    String hashed = passwordEncoder.encode(request.getPassword());
+    return userRepository.save(new User(username, hashed));
+  }
 
-    public TokenResponse login(LoginRequest request) {
-        Authentication authentication = authenticationManager.authenticate(
-                new UsernamePasswordAuthenticationToken(request.getUsername(), request.getPassword()));
-        String accessToken = jwtTokenProvider.generateToken(authentication.getName());
-        long expiresInSeconds = jwtTokenProvider.getExpirationMs() / 1000;
-        return new TokenResponse(accessToken, "Bearer", expiresInSeconds);
-    }
+  public TokenResponse login(LoginRequest request) {
+    Authentication authentication =
+        authenticationManager.authenticate(
+            new UsernamePasswordAuthenticationToken(request.getUsername(), request.getPassword()));
+    String accessToken = jwtTokenProvider.generateToken(authentication.getName());
+    long expiresInSeconds = jwtTokenProvider.getExpirationMs() / 1000;
+    return new TokenResponse(accessToken, "Bearer", expiresInSeconds);
+  }
 }

--- a/src/main/java/com/example/board/user/AuthViewController.java
+++ b/src/main/java/com/example/board/user/AuthViewController.java
@@ -14,63 +14,63 @@ import org.springframework.web.bind.annotation.PostMapping;
 @Controller
 public class AuthViewController {
 
-    private final AuthService authService;
+  private final AuthService authService;
 
-    public AuthViewController(AuthService authService) {
-        this.authService = authService;
-    }
+  public AuthViewController(AuthService authService) {
+    this.authService = authService;
+  }
 
-    @GetMapping("/signup")
-    public String signupForm(Model model) {
-        if (!model.containsAttribute("signupRequest")) {
-            model.addAttribute("signupRequest", new SignupRequest());
-        }
-        return "signup";
+  @GetMapping("/signup")
+  public String signupForm(Model model) {
+    if (!model.containsAttribute("signupRequest")) {
+      model.addAttribute("signupRequest", new SignupRequest());
     }
+    return "signup";
+  }
 
-    @PostMapping("/signup")
-    public String signupSubmit(
-            @Valid @ModelAttribute("signupRequest") SignupRequest signupRequest,
-            BindingResult bindingResult) {
-        if (bindingResult.hasErrors()) {
-            return "signup";
-        }
-        try {
-            authService.signup(signupRequest);
-        } catch (IllegalArgumentException ex) {
-            bindingResult.reject("signup.duplicate", ex.getMessage());
-            return "signup";
-        }
-        return "redirect:/signup?success=true";
+  @PostMapping("/signup")
+  public String signupSubmit(
+      @Valid @ModelAttribute("signupRequest") SignupRequest signupRequest,
+      BindingResult bindingResult) {
+    if (bindingResult.hasErrors()) {
+      return "signup";
     }
+    try {
+      authService.signup(signupRequest);
+    } catch (IllegalArgumentException ex) {
+      bindingResult.reject("signup.duplicate", ex.getMessage());
+      return "signup";
+    }
+    return "redirect:/signup?success=true";
+  }
 
-    @GetMapping("/login")
-    public String loginForm(Model model) {
-        if (!model.containsAttribute("loginRequest")) {
-            model.addAttribute("loginRequest", new LoginRequest());
-        }
-        return "login";
+  @GetMapping("/login")
+  public String loginForm(Model model) {
+    if (!model.containsAttribute("loginRequest")) {
+      model.addAttribute("loginRequest", new LoginRequest());
     }
+    return "login";
+  }
 
-    @PostMapping("/login")
-    public String loginSubmit(
-            @Valid @ModelAttribute("loginRequest") LoginRequest loginRequest,
-            BindingResult bindingResult,
-            HttpServletResponse response) {
-        if (bindingResult.hasErrors()) {
-            return "login";
-        }
-        try {
-            TokenResponse token = authService.login(loginRequest);
-            Cookie cookie = new Cookie("accessToken", token.accessToken());
-            cookie.setHttpOnly(true);
-            cookie.setPath("/");
-            cookie.setMaxAge((int) token.expiresIn());
-            response.addCookie(cookie);
-            return "redirect:/login?success=true";
-        } catch (AuthenticationException ex) {
-            bindingResult.reject("login.invalid", AuthErrorMessages.INVALID_CREDENTIALS);
-            return "login";
-        }
+  @PostMapping("/login")
+  public String loginSubmit(
+      @Valid @ModelAttribute("loginRequest") LoginRequest loginRequest,
+      BindingResult bindingResult,
+      HttpServletResponse response) {
+    if (bindingResult.hasErrors()) {
+      return "login";
     }
+    try {
+      TokenResponse token = authService.login(loginRequest);
+      Cookie cookie = new Cookie("accessToken", token.accessToken());
+      cookie.setHttpOnly(true);
+      cookie.setPath("/");
+      cookie.setMaxAge((int) token.expiresIn());
+      response.addCookie(cookie);
+      return "redirect:/login?success=true";
+    } catch (AuthenticationException ex) {
+      bindingResult.reject("login.invalid", AuthErrorMessages.INVALID_CREDENTIALS);
+      return "login";
+    }
+  }
 }

--- a/src/main/java/com/example/board/user/LoginRequest.java
+++ b/src/main/java/com/example/board/user/LoginRequest.java
@@ -4,33 +4,32 @@ import jakarta.validation.constraints.NotBlank;
 
 public class LoginRequest {
 
-    @NotBlank(message = "username은 필수입니다")
-    private String username;
+  @NotBlank(message = "username은 필수입니다")
+  private String username;
 
-    @NotBlank(message = "password는 필수입니다")
-    private String password;
+  @NotBlank(message = "password는 필수입니다")
+  private String password;
 
-    public LoginRequest() {
-    }
+  public LoginRequest() {}
 
-    public LoginRequest(String username, String password) {
-        this.username = username;
-        this.password = password;
-    }
+  public LoginRequest(String username, String password) {
+    this.username = username;
+    this.password = password;
+  }
 
-    public String getUsername() {
-        return username;
-    }
+  public String getUsername() {
+    return username;
+  }
 
-    public void setUsername(String username) {
-        this.username = username;
-    }
+  public void setUsername(String username) {
+    this.username = username;
+  }
 
-    public String getPassword() {
-        return password;
-    }
+  public String getPassword() {
+    return password;
+  }
 
-    public void setPassword(String password) {
-        this.password = password;
-    }
+  public void setPassword(String password) {
+    this.password = password;
+  }
 }

--- a/src/main/java/com/example/board/user/SignupRequest.java
+++ b/src/main/java/com/example/board/user/SignupRequest.java
@@ -5,35 +5,34 @@ import jakarta.validation.constraints.Size;
 
 public class SignupRequest {
 
-    @NotBlank(message = "username은 필수입니다")
-    @Size(min = 3, max = 20, message = "username은 3~20자여야 합니다")
-    private String username;
+  @NotBlank(message = "username은 필수입니다")
+  @Size(min = 3, max = 20, message = "username은 3~20자여야 합니다")
+  private String username;
 
-    @NotBlank(message = "password는 필수입니다")
-    @Size(min = 6, message = "password는 최소 6자여야 합니다")
-    private String password;
+  @NotBlank(message = "password는 필수입니다")
+  @Size(min = 6, message = "password는 최소 6자여야 합니다")
+  private String password;
 
-    public SignupRequest() {
-    }
+  public SignupRequest() {}
 
-    public SignupRequest(String username, String password) {
-        this.username = username;
-        this.password = password;
-    }
+  public SignupRequest(String username, String password) {
+    this.username = username;
+    this.password = password;
+  }
 
-    public String getUsername() {
-        return username;
-    }
+  public String getUsername() {
+    return username;
+  }
 
-    public void setUsername(String username) {
-        this.username = username;
-    }
+  public void setUsername(String username) {
+    this.username = username;
+  }
 
-    public String getPassword() {
-        return password;
-    }
+  public String getPassword() {
+    return password;
+  }
 
-    public void setPassword(String password) {
-        this.password = password;
-    }
+  public void setPassword(String password) {
+    this.password = password;
+  }
 }

--- a/src/main/java/com/example/board/user/TokenResponse.java
+++ b/src/main/java/com/example/board/user/TokenResponse.java
@@ -1,4 +1,3 @@
 package com.example.board.user;
 
-public record TokenResponse(String accessToken, String tokenType, long expiresIn) {
-}
+public record TokenResponse(String accessToken, String tokenType, long expiresIn) {}

--- a/src/main/java/com/example/board/user/User.java
+++ b/src/main/java/com/example/board/user/User.java
@@ -12,33 +12,32 @@ import jakarta.persistence.Table;
 @Table(name = "users")
 public class User extends BaseEntity {
 
-    @Id
-    @GeneratedValue(strategy = GenerationType.IDENTITY)
-    private Long id;
+  @Id
+  @GeneratedValue(strategy = GenerationType.IDENTITY)
+  private Long id;
 
-    @Column(nullable = false, unique = true, length = 20)
-    private String username;
+  @Column(nullable = false, unique = true, length = 20)
+  private String username;
 
-    @Column(nullable = false)
-    private String password;
+  @Column(nullable = false)
+  private String password;
 
-    protected User() {
-    }
+  protected User() {}
 
-    public User(String username, String password) {
-        this.username = username;
-        this.password = password;
-    }
+  public User(String username, String password) {
+    this.username = username;
+    this.password = password;
+  }
 
-    public Long getId() {
-        return id;
-    }
+  public Long getId() {
+    return id;
+  }
 
-    public String getUsername() {
-        return username;
-    }
+  public String getUsername() {
+    return username;
+  }
 
-    public String getPassword() {
-        return password;
-    }
+  public String getPassword() {
+    return password;
+  }
 }

--- a/src/main/java/com/example/board/user/UserRepository.java
+++ b/src/main/java/com/example/board/user/UserRepository.java
@@ -5,7 +5,7 @@ import org.springframework.data.jpa.repository.JpaRepository;
 
 public interface UserRepository extends JpaRepository<User, Long> {
 
-    boolean existsByUsername(String username);
+  boolean existsByUsername(String username);
 
-    Optional<User> findByUsername(String username);
+  Optional<User> findByUsername(String username);
 }

--- a/src/test/java/com/example/board/BoardApplicationContextLoadsTest.java
+++ b/src/test/java/com/example/board/BoardApplicationContextLoadsTest.java
@@ -8,7 +8,6 @@ import org.springframework.test.context.ActiveProfiles;
 @ActiveProfiles("test")
 class BoardApplicationContextLoadsTest {
 
-    @Test
-    void 스프링_컨텍스트가_정상적으로_로드된다() {
-    }
+  @Test
+  void 스프링_컨텍스트가_정상적으로_로드된다() {}
 }

--- a/src/test/java/com/example/board/common/BaseEntityAuditingTest.java
+++ b/src/test/java/com/example/board/common/BaseEntityAuditingTest.java
@@ -12,28 +12,27 @@ import org.springframework.test.context.ActiveProfiles;
 @ActiveProfiles("test")
 class BaseEntityAuditingTest {
 
-    @Autowired
-    ProbeRepository probeRepository;
+  @Autowired ProbeRepository probeRepository;
 
-    @Test
-    void 엔티티_저장시_createdAt과_updatedAt이_자동으로_채워진다() {
-        ProbeEntity saved = probeRepository.saveAndFlush(new ProbeEntity("hello"));
+  @Test
+  void 엔티티_저장시_createdAt과_updatedAt이_자동으로_채워진다() {
+    ProbeEntity saved = probeRepository.saveAndFlush(new ProbeEntity("hello"));
 
-        assertThat(saved.getCreatedAt()).isNotNull();
-        assertThat(saved.getUpdatedAt()).isNotNull();
-    }
+    assertThat(saved.getCreatedAt()).isNotNull();
+    assertThat(saved.getUpdatedAt()).isNotNull();
+  }
 
-    @Test
-    void 엔티티_수정시_updatedAt이_갱신되고_createdAt은_유지된다() throws InterruptedException {
-        ProbeEntity saved = probeRepository.saveAndFlush(new ProbeEntity("first"));
-        Instant originalCreatedAt = saved.getCreatedAt();
-        Instant originalUpdatedAt = saved.getUpdatedAt();
+  @Test
+  void 엔티티_수정시_updatedAt이_갱신되고_createdAt은_유지된다() throws InterruptedException {
+    ProbeEntity saved = probeRepository.saveAndFlush(new ProbeEntity("first"));
+    Instant originalCreatedAt = saved.getCreatedAt();
+    Instant originalUpdatedAt = saved.getUpdatedAt();
 
-        Thread.sleep(10);
-        saved.setName("second");
-        ProbeEntity updated = probeRepository.saveAndFlush(saved);
+    Thread.sleep(10);
+    saved.setName("second");
+    ProbeEntity updated = probeRepository.saveAndFlush(saved);
 
-        assertThat(updated.getCreatedAt()).isEqualTo(originalCreatedAt);
-        assertThat(updated.getUpdatedAt()).isAfterOrEqualTo(originalUpdatedAt);
-    }
+    assertThat(updated.getCreatedAt()).isEqualTo(originalCreatedAt);
+    assertThat(updated.getUpdatedAt()).isAfterOrEqualTo(originalUpdatedAt);
+  }
 }

--- a/src/test/java/com/example/board/common/ExceptionProbeController.java
+++ b/src/test/java/com/example/board/common/ExceptionProbeController.java
@@ -12,34 +12,32 @@ import org.springframework.web.bind.annotation.RequestMapping;
 import org.springframework.web.bind.annotation.RestController;
 
 @RestController
-@RequestMapping("/__probe")
+@RequestMapping("/api/__probe")
 @Profile("test")
 class ExceptionProbeController {
 
-    @PostMapping("/validation")
-    void validation(@Valid @RequestBody ProbeRequest request) {
-    }
+  @PostMapping("/validation")
+  void validation(@Valid @RequestBody ProbeRequest request) {}
 
-    @GetMapping("/runtime")
-    String runtime() {
-        throw new RuntimeException("boom-do-not-leak");
-    }
+  @GetMapping("/runtime")
+  String runtime() {
+    throw new RuntimeException("boom-do-not-leak");
+  }
 
-    @GetMapping("/access-denied")
-    String accessDenied() {
-        throw new AccessDeniedException("nope");
-    }
+  @GetMapping("/access-denied")
+  String accessDenied() {
+    throw new AccessDeniedException("nope");
+  }
 
-    @GetMapping("/illegal")
-    String illegal() {
-        throw new IllegalArgumentException("bad argument");
-    }
+  @GetMapping("/illegal")
+  String illegal() {
+    throw new IllegalArgumentException("bad argument");
+  }
 
-    @GetMapping("/secured")
-    String secured() {
-        return "ok";
-    }
+  @GetMapping("/secured")
+  String secured() {
+    return "ok";
+  }
 
-    record ProbeRequest(@NotBlank String name, @Min(1) int age) {
-    }
+  record ProbeRequest(@NotBlank String name, @Min(1) int age) {}
 }

--- a/src/test/java/com/example/board/common/GlobalExceptionHandlerTest.java
+++ b/src/test/java/com/example/board/common/GlobalExceptionHandlerTest.java
@@ -20,58 +20,63 @@ import org.springframework.test.web.servlet.MockMvc;
 @ActiveProfiles("test")
 class GlobalExceptionHandlerTest {
 
-    @Autowired
-    MockMvc mockMvc;
+  @Autowired MockMvc mockMvc;
 
-    @Test
-    void 요청한_경로가_없으면_404_JSON을_반환한다() throws Exception {
-        mockMvc.perform(get("/definitely-not-exist"))
-                .andExpect(status().isNotFound())
-                .andExpect(jsonPath("$.status").value(404))
-                .andExpect(jsonPath("$.error").value("Not Found"))
-                .andExpect(jsonPath("$.message").exists())
-                .andExpect(jsonPath("$.path").value("/definitely-not-exist"))
-                .andExpect(jsonPath("$.timestamp").exists());
-    }
+  @Test
+  void 요청한_경로가_없으면_404_JSON을_반환한다() throws Exception {
+    mockMvc
+        .perform(get("/api/definitely-not-exist"))
+        .andExpect(status().isNotFound())
+        .andExpect(jsonPath("$.status").value(404))
+        .andExpect(jsonPath("$.error").value("Not Found"))
+        .andExpect(jsonPath("$.message").exists())
+        .andExpect(jsonPath("$.path").value("/api/definitely-not-exist"))
+        .andExpect(jsonPath("$.timestamp").exists());
+  }
 
-    @Test
-    void 검증_실패시_400_JSON을_반환하고_필드명을_포함한다() throws Exception {
-        mockMvc.perform(post("/__probe/validation")
-                        .contentType(MediaType.APPLICATION_JSON)
-                        .content("{\"name\":\"\",\"age\":0}"))
-                .andExpect(status().isBadRequest())
-                .andExpect(jsonPath("$.status").value(400))
-                .andExpect(jsonPath("$.error").value("Bad Request"))
-                .andExpect(jsonPath("$.message").value(containsString("name")))
-                .andExpect(jsonPath("$.path").value("/__probe/validation"))
-                .andExpect(jsonPath("$.timestamp").exists());
-    }
+  @Test
+  void 검증_실패시_400_JSON을_반환하고_필드명을_포함한다() throws Exception {
+    mockMvc
+        .perform(
+            post("/api/__probe/validation")
+                .contentType(MediaType.APPLICATION_JSON)
+                .content("{\"name\":\"\",\"age\":0}"))
+        .andExpect(status().isBadRequest())
+        .andExpect(jsonPath("$.status").value(400))
+        .andExpect(jsonPath("$.error").value("Bad Request"))
+        .andExpect(jsonPath("$.message").value(containsString("name")))
+        .andExpect(jsonPath("$.path").value("/api/__probe/validation"))
+        .andExpect(jsonPath("$.timestamp").exists());
+  }
 
-    @Test
-    void 런타임예외는_500_JSON을_반환하고_스택트레이스를_숨긴다() throws Exception {
-        mockMvc.perform(get("/__probe/runtime"))
-                .andExpect(status().isInternalServerError())
-                .andExpect(jsonPath("$.status").value(500))
-                .andExpect(jsonPath("$.error").value("Internal Server Error"))
-                .andExpect(jsonPath("$.message").value(not(containsString("boom-do-not-leak"))))
-                .andExpect(jsonPath("$.message").value(not(containsString("RuntimeException"))))
-                .andExpect(jsonPath("$.path").value("/__probe/runtime"));
-    }
+  @Test
+  void 런타임예외는_500_JSON을_반환하고_스택트레이스를_숨긴다() throws Exception {
+    mockMvc
+        .perform(get("/api/__probe/runtime"))
+        .andExpect(status().isInternalServerError())
+        .andExpect(jsonPath("$.status").value(500))
+        .andExpect(jsonPath("$.error").value("Internal Server Error"))
+        .andExpect(jsonPath("$.message").value(not(containsString("boom-do-not-leak"))))
+        .andExpect(jsonPath("$.message").value(not(containsString("RuntimeException"))))
+        .andExpect(jsonPath("$.path").value("/api/__probe/runtime"));
+  }
 
-    @Test
-    void 접근_거부는_403_JSON을_반환한다() throws Exception {
-        mockMvc.perform(get("/__probe/access-denied"))
-                .andExpect(status().isForbidden())
-                .andExpect(jsonPath("$.status").value(403))
-                .andExpect(jsonPath("$.error").value("Forbidden"))
-                .andExpect(jsonPath("$.path").value("/__probe/access-denied"));
-    }
+  @Test
+  void 접근_거부는_403_JSON을_반환한다() throws Exception {
+    mockMvc
+        .perform(get("/api/__probe/access-denied"))
+        .andExpect(status().isForbidden())
+        .andExpect(jsonPath("$.status").value(403))
+        .andExpect(jsonPath("$.error").value("Forbidden"))
+        .andExpect(jsonPath("$.path").value("/api/__probe/access-denied"));
+  }
 
-    @Test
-    void IllegalArgument는_400_JSON을_반환한다() throws Exception {
-        mockMvc.perform(get("/__probe/illegal"))
-                .andExpect(status().isBadRequest())
-                .andExpect(jsonPath("$.status").value(400))
-                .andExpect(jsonPath("$.message").value(containsString("bad argument")));
-    }
+  @Test
+  void IllegalArgument는_400_JSON을_반환한다() throws Exception {
+    mockMvc
+        .perform(get("/api/__probe/illegal"))
+        .andExpect(status().isBadRequest())
+        .andExpect(jsonPath("$.status").value(400))
+        .andExpect(jsonPath("$.message").value(containsString("bad argument")));
+  }
 }

--- a/src/test/java/com/example/board/common/ProbeEntity.java
+++ b/src/test/java/com/example/board/common/ProbeEntity.java
@@ -10,28 +10,27 @@ import jakarta.persistence.Table;
 @Table(name = "probe")
 class ProbeEntity extends BaseEntity {
 
-    @Id
-    @GeneratedValue(strategy = GenerationType.IDENTITY)
-    private Long id;
+  @Id
+  @GeneratedValue(strategy = GenerationType.IDENTITY)
+  private Long id;
 
-    private String name;
+  private String name;
 
-    protected ProbeEntity() {
-    }
+  protected ProbeEntity() {}
 
-    ProbeEntity(String name) {
-        this.name = name;
-    }
+  ProbeEntity(String name) {
+    this.name = name;
+  }
 
-    Long getId() {
-        return id;
-    }
+  Long getId() {
+    return id;
+  }
 
-    String getName() {
-        return name;
-    }
+  String getName() {
+    return name;
+  }
 
-    void setName(String name) {
-        this.name = name;
-    }
+  void setName(String name) {
+    this.name = name;
+  }
 }

--- a/src/test/java/com/example/board/common/ProbeRepository.java
+++ b/src/test/java/com/example/board/common/ProbeRepository.java
@@ -2,5 +2,4 @@ package com.example.board.common;
 
 import org.springframework.data.jpa.repository.JpaRepository;
 
-interface ProbeRepository extends JpaRepository<ProbeEntity, Long> {
-}
+interface ProbeRepository extends JpaRepository<ProbeEntity, Long> {}

--- a/src/test/java/com/example/board/config/RestAccessDeniedHandlerTest.java
+++ b/src/test/java/com/example/board/config/RestAccessDeniedHandlerTest.java
@@ -11,26 +11,25 @@ import org.springframework.security.access.AccessDeniedException;
 
 class RestAccessDeniedHandlerTest {
 
-    private final ObjectMapper objectMapper =
-            new ObjectMapper().registerModule(new JavaTimeModule());
+  private final ObjectMapper objectMapper = new ObjectMapper().registerModule(new JavaTimeModule());
 
-    @Test
-    void 핸들러가_호출되면_403과_ErrorResponse_JSON을_기록한다() throws Exception {
-        RestAccessDeniedHandler handler = new RestAccessDeniedHandler(objectMapper);
-        MockHttpServletRequest request = new MockHttpServletRequest("GET", "/api/some");
-        MockHttpServletResponse response = new MockHttpServletResponse();
+  @Test
+  void 핸들러가_호출되면_403과_ErrorResponse_JSON을_기록한다() throws Exception {
+    RestAccessDeniedHandler handler = new RestAccessDeniedHandler(objectMapper);
+    MockHttpServletRequest request = new MockHttpServletRequest("GET", "/api/some");
+    MockHttpServletResponse response = new MockHttpServletResponse();
 
-        handler.handle(request, response, new AccessDeniedException("거부"));
+    handler.handle(request, response, new AccessDeniedException("거부"));
 
-        assertThat(response.getStatus()).isEqualTo(403);
-        assertThat(response.getContentType()).contains("application/json");
-        assertThat(response.getCharacterEncoding()).isEqualToIgnoringCase("UTF-8");
+    assertThat(response.getStatus()).isEqualTo(403);
+    assertThat(response.getContentType()).contains("application/json");
+    assertThat(response.getCharacterEncoding()).isEqualToIgnoringCase("UTF-8");
 
-        String body = response.getContentAsString();
-        assertThat(body).contains("\"status\":403");
-        assertThat(body).contains("\"error\":\"Forbidden\"");
-        assertThat(body).contains("\"message\":\"접근이 거부되었습니다\"");
-        assertThat(body).contains("\"path\":\"/api/some\"");
-        assertThat(body).contains("\"timestamp\"");
-    }
+    String body = response.getContentAsString();
+    assertThat(body).contains("\"status\":403");
+    assertThat(body).contains("\"error\":\"Forbidden\"");
+    assertThat(body).contains("\"message\":\"접근이 거부되었습니다\"");
+    assertThat(body).contains("\"path\":\"/api/some\"");
+    assertThat(body).contains("\"timestamp\"");
+  }
 }

--- a/src/test/java/com/example/board/config/SecurityConfigTest.java
+++ b/src/test/java/com/example/board/config/SecurityConfigTest.java
@@ -18,33 +18,35 @@ import org.springframework.test.web.servlet.MockMvc;
 @ActiveProfiles("test")
 class SecurityConfigTest {
 
-    @Autowired
-    MockMvc mockMvc;
+  @Autowired MockMvc mockMvc;
 
-    @Test
-    void 인증없이_보호경로에_접근하면_401_JSON을_반환한다() throws Exception {
-        mockMvc.perform(get("/__probe/secured"))
-                .andExpect(status().isUnauthorized())
-                .andExpect(jsonPath("$.status").value(401))
-                .andExpect(jsonPath("$.error").value("Unauthorized"))
-                .andExpect(jsonPath("$.message").exists())
-                .andExpect(jsonPath("$.path").value("/__probe/secured"))
-                .andExpect(jsonPath("$.timestamp").exists());
-    }
+  @Test
+  void 인증없이_보호경로에_접근하면_401_JSON을_반환한다() throws Exception {
+    mockMvc
+        .perform(get("/api/__probe/secured"))
+        .andExpect(status().isUnauthorized())
+        .andExpect(jsonPath("$.status").value(401))
+        .andExpect(jsonPath("$.error").value("Unauthorized"))
+        .andExpect(jsonPath("$.message").exists())
+        .andExpect(jsonPath("$.path").value("/api/__probe/secured"))
+        .andExpect(jsonPath("$.timestamp").exists());
+  }
 
-    @Test
-    void H2콘솔은_인증없이_접근가능하다() throws Exception {
-        mockMvc.perform(get("/h2-console/"))
-                .andExpect(status().is(not(401)))
-                .andExpect(status().is(not(403)));
-    }
+  @Test
+  void H2콘솔은_인증없이_접근가능하다() throws Exception {
+    mockMvc
+        .perform(get("/h2-console/"))
+        .andExpect(status().is(not(401)))
+        .andExpect(status().is(not(403)));
+  }
 
-    @Test
-    void 존재하지않는_API경로는_인증여부와_무관하게_404를_반환한다() throws Exception {
-        mockMvc.perform(get("/api/definitely-not-exist"))
-                .andExpect(status().is(Matchers.anyOf(Matchers.is(401), Matchers.is(404))));
-        // NOTE: 현재 정책은 보안 필터가 먼저 돌아 401을 낼 수도 있음.
-        // 이 edge case를 여기서 고정하고, 의도한 최종 동작은 404여야 함.
-        // GREEN 후에는 401 또는 404 중 문서화된 결정값으로 수렴시킨다.
-    }
+  @Test
+  void 존재하지않는_API경로는_인증여부와_무관하게_404를_반환한다() throws Exception {
+    mockMvc
+        .perform(get("/api/definitely-not-exist"))
+        .andExpect(status().is(Matchers.anyOf(Matchers.is(401), Matchers.is(404))));
+    // NOTE: 현재 정책은 보안 필터가 먼저 돌아 401을 낼 수도 있음.
+    // 이 edge case를 여기서 고정하고, 의도한 최종 동작은 404여야 함.
+    // GREEN 후에는 401 또는 404 중 문서화된 결정값으로 수렴시킨다.
+  }
 }

--- a/src/test/java/com/example/board/config/SpaFallbackTest.java
+++ b/src/test/java/com/example/board/config/SpaFallbackTest.java
@@ -1,0 +1,88 @@
+package com.example.board.config;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.hamcrest.Matchers.not;
+import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.get;
+import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.post;
+import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.forwardedUrl;
+import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.status;
+
+import org.junit.jupiter.api.Test;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.boot.test.autoconfigure.web.servlet.AutoConfigureMockMvc;
+import org.springframework.boot.test.context.SpringBootTest;
+import org.springframework.test.context.ActiveProfiles;
+import org.springframework.test.web.servlet.MockMvc;
+
+@SpringBootTest
+@AutoConfigureMockMvc
+@ActiveProfiles("test")
+class SpaFallbackTest {
+
+  @Autowired MockMvc mockMvc;
+
+  @Test
+  void GET_루트는_index_html로_forward한다() throws Exception {
+    mockMvc.perform(get("/")).andExpect(status().isOk()).andExpect(forwardedUrl("/index.html"));
+  }
+
+  @Test
+  void GET_매칭되지않은_경로는_index_html로_forward한다() throws Exception {
+    mockMvc
+        .perform(get("/random-route"))
+        .andExpect(status().isOk())
+        .andExpect(forwardedUrl("/index.html"));
+  }
+
+  @Test
+  void GET_중첩_경로도_index_html로_forward한다() throws Exception {
+    mockMvc
+        .perform(get("/board/123"))
+        .andExpect(status().isOk())
+        .andExpect(forwardedUrl("/index.html"));
+  }
+
+  @Test
+  void GET_api_경로는_폴백되지않고_404를_반환한다() throws Exception {
+    mockMvc
+        .perform(get("/api/auth/nonexistent"))
+        .andExpect(status().isNotFound())
+        .andExpect(result -> assertThat(result.getResponse().getForwardedUrl()).isNull());
+  }
+
+  @Test
+  void GET_점이포함된_정적자원은_폴백되지않는다() throws Exception {
+    mockMvc
+        .perform(get("/favicon.ico"))
+        .andExpect(result -> assertThat(result.getResponse().getForwardedUrl()).isNull());
+
+    mockMvc
+        .perform(get("/assets/main.js"))
+        .andExpect(status().isNotFound())
+        .andExpect(result -> assertThat(result.getResponse().getForwardedUrl()).isNull());
+  }
+
+  @Test
+  void POST_매칭되지않은_경로는_폴백되지않는다() throws Exception {
+    mockMvc
+        .perform(post("/random-route"))
+        .andExpect(result -> assertThat(result.getResponse().getForwardedUrl()).isNull());
+  }
+
+  @Test
+  void GET_h2_console_경로는_폴백되지않는다() throws Exception {
+    mockMvc
+        .perform(get("/h2-console/"))
+        .andExpect(status().is(not(401)))
+        .andExpect(status().is(not(403)))
+        .andExpect(result -> assertThat(result.getResponse().getForwardedUrl()).isNull());
+  }
+
+  @Test
+  void GET_signup_thymeleaf는_여전히_동작한다() throws Exception {
+    mockMvc
+        .perform(get("/signup"))
+        .andExpect(status().isOk())
+        .andExpect(result -> assertThat(result.getResponse().getForwardedUrl()).isNull());
+  }
+}

--- a/src/test/java/com/example/board/post/PostCrudControllerTest.java
+++ b/src/test/java/com/example/board/post/PostCrudControllerTest.java
@@ -28,262 +28,287 @@ import org.springframework.test.web.servlet.MockMvc;
 @ActiveProfiles("test")
 class PostCrudControllerTest {
 
-    @Autowired MockMvc mockMvc;
-    @Autowired PostRepository postRepository;
-    @Autowired UserRepository userRepository;
-    @Autowired PasswordEncoder passwordEncoder;
-    @Autowired JwtTokenProvider jwtTokenProvider;
+  @Autowired MockMvc mockMvc;
+  @Autowired PostRepository postRepository;
+  @Autowired UserRepository userRepository;
+  @Autowired PasswordEncoder passwordEncoder;
+  @Autowired JwtTokenProvider jwtTokenProvider;
 
-    User alice;
-    User bob;
-    String aliceToken;
-    String bobToken;
+  User alice;
+  User bob;
+  String aliceToken;
+  String bobToken;
 
-    @BeforeEach
-    void setUp() {
-        postRepository.deleteAll();
-        userRepository.deleteAll();
-        alice = userRepository.save(new User("alice", passwordEncoder.encode("pw12345")));
-        bob = userRepository.save(new User("bob", passwordEncoder.encode("pw12345")));
-        aliceToken = "Bearer " + jwtTokenProvider.generateToken("alice");
-        bobToken = "Bearer " + jwtTokenProvider.generateToken("bob");
-    }
+  @BeforeEach
+  void setUp() {
+    postRepository.deleteAll();
+    userRepository.deleteAll();
+    alice = userRepository.save(new User("alice", passwordEncoder.encode("pw12345")));
+    bob = userRepository.save(new User("bob", passwordEncoder.encode("pw12345")));
+    aliceToken = "Bearer " + jwtTokenProvider.generateToken("alice");
+    bobToken = "Bearer " + jwtTokenProvider.generateToken("bob");
+  }
 
-    @AfterEach
-    void tearDown() {
-        postRepository.deleteAll();
-        userRepository.deleteAll();
-    }
+  @AfterEach
+  void tearDown() {
+    postRepository.deleteAll();
+    userRepository.deleteAll();
+  }
 
-    // -------- Happy path --------
+  // -------- Happy path --------
 
-    @Test
-    void 단건조회_존재하는_id면_200과_필드_일치() throws Exception {
-        Post saved = postRepository.save(new Post("hello", "world", alice));
+  @Test
+  void 단건조회_존재하는_id면_200과_필드_일치() throws Exception {
+    Post saved = postRepository.save(new Post("hello", "world", alice));
 
-        mockMvc.perform(get("/api/posts/" + saved.getId()))
-                .andExpect(status().isOk())
-                .andExpect(jsonPath("$.id").value(saved.getId()))
-                .andExpect(jsonPath("$.title").value("hello"))
-                .andExpect(jsonPath("$.content").value("world"))
-                .andExpect(jsonPath("$.authorUsername").value("alice"))
-                .andExpect(jsonPath("$.createdAt").exists())
-                .andExpect(jsonPath("$.updatedAt").exists());
-    }
+    mockMvc
+        .perform(get("/api/posts/" + saved.getId()))
+        .andExpect(status().isOk())
+        .andExpect(jsonPath("$.id").value(saved.getId()))
+        .andExpect(jsonPath("$.title").value("hello"))
+        .andExpect(jsonPath("$.content").value("world"))
+        .andExpect(jsonPath("$.authorUsername").value("alice"))
+        .andExpect(jsonPath("$.createdAt").exists())
+        .andExpect(jsonPath("$.updatedAt").exists());
+  }
 
-    @Test
-    void 단건조회는_인증없이_접근_가능하다() throws Exception {
-        Post saved = postRepository.save(new Post("hello", "world", alice));
-        mockMvc.perform(get("/api/posts/" + saved.getId()))
-                .andExpect(status().isOk());
-    }
+  @Test
+  void 단건조회는_인증없이_접근_가능하다() throws Exception {
+    Post saved = postRepository.save(new Post("hello", "world", alice));
+    mockMvc.perform(get("/api/posts/" + saved.getId())).andExpect(status().isOk());
+  }
 
-    @Test
-    void 작성_인증된_사용자면_201과_authorUsername_일치() throws Exception {
-        mockMvc.perform(post("/api/posts")
-                        .header("Authorization", aliceToken)
-                        .contentType(MediaType.APPLICATION_JSON)
-                        .content("{\"title\":\"첫 글\",\"content\":\"본문\"}"))
-                .andExpect(status().isCreated())
-                .andExpect(jsonPath("$.id").isNumber())
-                .andExpect(jsonPath("$.title").value("첫 글"))
-                .andExpect(jsonPath("$.content").value("본문"))
-                .andExpect(jsonPath("$.authorUsername").value("alice"))
-                .andExpect(jsonPath("$.createdAt").exists())
-                .andExpect(jsonPath("$.updatedAt").exists());
-    }
+  @Test
+  void 작성_인증된_사용자면_201과_authorUsername_일치() throws Exception {
+    mockMvc
+        .perform(
+            post("/api/posts")
+                .header("Authorization", aliceToken)
+                .contentType(MediaType.APPLICATION_JSON)
+                .content("{\"title\":\"첫 글\",\"content\":\"본문\"}"))
+        .andExpect(status().isCreated())
+        .andExpect(jsonPath("$.id").isNumber())
+        .andExpect(jsonPath("$.title").value("첫 글"))
+        .andExpect(jsonPath("$.content").value("본문"))
+        .andExpect(jsonPath("$.authorUsername").value("alice"))
+        .andExpect(jsonPath("$.createdAt").exists())
+        .andExpect(jsonPath("$.updatedAt").exists());
+  }
 
-    @Test
-    void 수정_본인이면_200과_변경된_필드가_반영된다() throws Exception {
-        Post saved = postRepository.save(new Post("old", "old-body", alice));
+  @Test
+  void 수정_본인이면_200과_변경된_필드가_반영된다() throws Exception {
+    Post saved = postRepository.save(new Post("old", "old-body", alice));
 
-        mockMvc.perform(put("/api/posts/" + saved.getId())
-                        .header("Authorization", aliceToken)
-                        .contentType(MediaType.APPLICATION_JSON)
-                        .content("{\"title\":\"new\",\"content\":\"new-body\"}"))
-                .andExpect(status().isOk())
-                .andExpect(jsonPath("$.id").value(saved.getId()))
-                .andExpect(jsonPath("$.title").value("new"))
-                .andExpect(jsonPath("$.content").value("new-body"))
-                .andExpect(jsonPath("$.authorUsername").value("alice"));
+    mockMvc
+        .perform(
+            put("/api/posts/" + saved.getId())
+                .header("Authorization", aliceToken)
+                .contentType(MediaType.APPLICATION_JSON)
+                .content("{\"title\":\"new\",\"content\":\"new-body\"}"))
+        .andExpect(status().isOk())
+        .andExpect(jsonPath("$.id").value(saved.getId()))
+        .andExpect(jsonPath("$.title").value("new"))
+        .andExpect(jsonPath("$.content").value("new-body"))
+        .andExpect(jsonPath("$.authorUsername").value("alice"));
 
-        Post reloaded = postRepository.findById(saved.getId()).orElseThrow();
-        assertThat(reloaded.getTitle()).isEqualTo("new");
-        assertThat(reloaded.getContent()).isEqualTo("new-body");
-    }
+    Post reloaded = postRepository.findById(saved.getId()).orElseThrow();
+    assertThat(reloaded.getTitle()).isEqualTo("new");
+    assertThat(reloaded.getContent()).isEqualTo("new-body");
+  }
 
-    @Test
-    void 삭제_본인이면_204이고_다시_조회하면_404() throws Exception {
-        Post saved = postRepository.save(new Post("t", "c", alice));
+  @Test
+  void 삭제_본인이면_204이고_다시_조회하면_404() throws Exception {
+    Post saved = postRepository.save(new Post("t", "c", alice));
 
-        mockMvc.perform(delete("/api/posts/" + saved.getId())
-                        .header("Authorization", aliceToken))
-                .andExpect(status().isNoContent());
+    mockMvc
+        .perform(delete("/api/posts/" + saved.getId()).header("Authorization", aliceToken))
+        .andExpect(status().isNoContent());
 
-        mockMvc.perform(get("/api/posts/" + saved.getId()))
-                .andExpect(status().isNotFound());
-    }
+    mockMvc.perform(get("/api/posts/" + saved.getId())).andExpect(status().isNotFound());
+  }
 
-    // -------- Input validation (400) --------
+  // -------- Input validation (400) --------
 
-    @Test
-    void 작성_title이_null이면_400() throws Exception {
-        mockMvc.perform(post("/api/posts")
-                        .header("Authorization", aliceToken)
-                        .contentType(MediaType.APPLICATION_JSON)
-                        .content("{\"content\":\"본문\"}"))
-                .andExpect(status().isBadRequest())
-                .andExpect(jsonPath("$.message").value(containsString("title")));
-    }
+  @Test
+  void 작성_title이_null이면_400() throws Exception {
+    mockMvc
+        .perform(
+            post("/api/posts")
+                .header("Authorization", aliceToken)
+                .contentType(MediaType.APPLICATION_JSON)
+                .content("{\"content\":\"본문\"}"))
+        .andExpect(status().isBadRequest())
+        .andExpect(jsonPath("$.message").value(containsString("title")));
+  }
 
-    @Test
-    void 작성_title이_빈문자열이면_400() throws Exception {
-        mockMvc.perform(post("/api/posts")
-                        .header("Authorization", aliceToken)
-                        .contentType(MediaType.APPLICATION_JSON)
-                        .content("{\"title\":\"\",\"content\":\"본문\"}"))
-                .andExpect(status().isBadRequest());
-    }
+  @Test
+  void 작성_title이_빈문자열이면_400() throws Exception {
+    mockMvc
+        .perform(
+            post("/api/posts")
+                .header("Authorization", aliceToken)
+                .contentType(MediaType.APPLICATION_JSON)
+                .content("{\"title\":\"\",\"content\":\"본문\"}"))
+        .andExpect(status().isBadRequest());
+  }
 
-    @Test
-    void 작성_title이_101자면_400() throws Exception {
-        String title = "a".repeat(101);
-        String body = "{\"title\":\"" + title + "\",\"content\":\"본문\"}";
-        mockMvc.perform(post("/api/posts")
-                        .header("Authorization", aliceToken)
-                        .contentType(MediaType.APPLICATION_JSON)
-                        .content(body))
-                .andExpect(status().isBadRequest());
-    }
+  @Test
+  void 작성_title이_101자면_400() throws Exception {
+    String title = "a".repeat(101);
+    String body = "{\"title\":\"" + title + "\",\"content\":\"본문\"}";
+    mockMvc
+        .perform(
+            post("/api/posts")
+                .header("Authorization", aliceToken)
+                .contentType(MediaType.APPLICATION_JSON)
+                .content(body))
+        .andExpect(status().isBadRequest());
+  }
 
-    @Test
-    void 작성_content가_null이면_400() throws Exception {
-        mockMvc.perform(post("/api/posts")
-                        .header("Authorization", aliceToken)
-                        .contentType(MediaType.APPLICATION_JSON)
-                        .content("{\"title\":\"제목\"}"))
-                .andExpect(status().isBadRequest())
-                .andExpect(jsonPath("$.message").value(containsString("content")));
-    }
+  @Test
+  void 작성_content가_null이면_400() throws Exception {
+    mockMvc
+        .perform(
+            post("/api/posts")
+                .header("Authorization", aliceToken)
+                .contentType(MediaType.APPLICATION_JSON)
+                .content("{\"title\":\"제목\"}"))
+        .andExpect(status().isBadRequest())
+        .andExpect(jsonPath("$.message").value(containsString("content")));
+  }
 
-    @Test
-    void 작성_content가_빈문자열이면_400() throws Exception {
-        mockMvc.perform(post("/api/posts")
-                        .header("Authorization", aliceToken)
-                        .contentType(MediaType.APPLICATION_JSON)
-                        .content("{\"title\":\"제목\",\"content\":\"\"}"))
-                .andExpect(status().isBadRequest());
-    }
+  @Test
+  void 작성_content가_빈문자열이면_400() throws Exception {
+    mockMvc
+        .perform(
+            post("/api/posts")
+                .header("Authorization", aliceToken)
+                .contentType(MediaType.APPLICATION_JSON)
+                .content("{\"title\":\"제목\",\"content\":\"\"}"))
+        .andExpect(status().isBadRequest());
+  }
 
-    @Test
-    void 수정_title이_null이면_400() throws Exception {
-        Post saved = postRepository.save(new Post("t", "c", alice));
-        mockMvc.perform(put("/api/posts/" + saved.getId())
-                        .header("Authorization", aliceToken)
-                        .contentType(MediaType.APPLICATION_JSON)
-                        .content("{\"content\":\"본문\"}"))
-                .andExpect(status().isBadRequest());
-    }
+  @Test
+  void 수정_title이_null이면_400() throws Exception {
+    Post saved = postRepository.save(new Post("t", "c", alice));
+    mockMvc
+        .perform(
+            put("/api/posts/" + saved.getId())
+                .header("Authorization", aliceToken)
+                .contentType(MediaType.APPLICATION_JSON)
+                .content("{\"content\":\"본문\"}"))
+        .andExpect(status().isBadRequest());
+  }
 
-    @Test
-    void 수정_content가_빈문자열이면_400() throws Exception {
-        Post saved = postRepository.save(new Post("t", "c", alice));
-        mockMvc.perform(put("/api/posts/" + saved.getId())
-                        .header("Authorization", aliceToken)
-                        .contentType(MediaType.APPLICATION_JSON)
-                        .content("{\"title\":\"t\",\"content\":\"\"}"))
-                .andExpect(status().isBadRequest());
-    }
+  @Test
+  void 수정_content가_빈문자열이면_400() throws Exception {
+    Post saved = postRepository.save(new Post("t", "c", alice));
+    mockMvc
+        .perform(
+            put("/api/posts/" + saved.getId())
+                .header("Authorization", aliceToken)
+                .contentType(MediaType.APPLICATION_JSON)
+                .content("{\"title\":\"t\",\"content\":\"\"}"))
+        .andExpect(status().isBadRequest());
+  }
 
-    // -------- Authentication (401) --------
+  // -------- Authentication (401) --------
 
-    @Test
-    void 작성_토큰없으면_401() throws Exception {
-        mockMvc.perform(post("/api/posts")
-                        .contentType(MediaType.APPLICATION_JSON)
-                        .content("{\"title\":\"t\",\"content\":\"c\"}"))
-                .andExpect(status().isUnauthorized());
-    }
+  @Test
+  void 작성_토큰없으면_401() throws Exception {
+    mockMvc
+        .perform(
+            post("/api/posts")
+                .contentType(MediaType.APPLICATION_JSON)
+                .content("{\"title\":\"t\",\"content\":\"c\"}"))
+        .andExpect(status().isUnauthorized());
+  }
 
-    @Test
-    void 수정_토큰없으면_401() throws Exception {
-        Post saved = postRepository.save(new Post("t", "c", alice));
-        mockMvc.perform(put("/api/posts/" + saved.getId())
-                        .contentType(MediaType.APPLICATION_JSON)
-                        .content("{\"title\":\"t\",\"content\":\"c\"}"))
-                .andExpect(status().isUnauthorized());
-    }
+  @Test
+  void 수정_토큰없으면_401() throws Exception {
+    Post saved = postRepository.save(new Post("t", "c", alice));
+    mockMvc
+        .perform(
+            put("/api/posts/" + saved.getId())
+                .contentType(MediaType.APPLICATION_JSON)
+                .content("{\"title\":\"t\",\"content\":\"c\"}"))
+        .andExpect(status().isUnauthorized());
+  }
 
-    @Test
-    void 삭제_토큰없으면_401() throws Exception {
-        Post saved = postRepository.save(new Post("t", "c", alice));
-        mockMvc.perform(delete("/api/posts/" + saved.getId()))
-                .andExpect(status().isUnauthorized());
-    }
+  @Test
+  void 삭제_토큰없으면_401() throws Exception {
+    Post saved = postRepository.save(new Post("t", "c", alice));
+    mockMvc.perform(delete("/api/posts/" + saved.getId())).andExpect(status().isUnauthorized());
+  }
 
-    // -------- Ownership (403) --------
+  // -------- Ownership (403) --------
 
-    @Test
-    void 타인의_글_수정_시도면_403이고_원본이_유지된다() throws Exception {
-        Post saved = postRepository.save(new Post("t", "c", alice));
+  @Test
+  void 타인의_글_수정_시도면_403이고_원본이_유지된다() throws Exception {
+    Post saved = postRepository.save(new Post("t", "c", alice));
 
-        mockMvc.perform(put("/api/posts/" + saved.getId())
-                        .header("Authorization", bobToken)
-                        .contentType(MediaType.APPLICATION_JSON)
-                        .content("{\"title\":\"hacked\",\"content\":\"x\"}"))
-                .andExpect(status().isForbidden());
+    mockMvc
+        .perform(
+            put("/api/posts/" + saved.getId())
+                .header("Authorization", bobToken)
+                .contentType(MediaType.APPLICATION_JSON)
+                .content("{\"title\":\"hacked\",\"content\":\"x\"}"))
+        .andExpect(status().isForbidden());
 
-        Post reloaded = postRepository.findById(saved.getId()).orElseThrow();
-        assertThat(reloaded.getTitle()).isEqualTo("t");
-        assertThat(reloaded.getContent()).isEqualTo("c");
-    }
+    Post reloaded = postRepository.findById(saved.getId()).orElseThrow();
+    assertThat(reloaded.getTitle()).isEqualTo("t");
+    assertThat(reloaded.getContent()).isEqualTo("c");
+  }
 
-    @Test
-    void 타인의_글_삭제_시도면_403이고_원본이_남아있다() throws Exception {
-        Post saved = postRepository.save(new Post("t", "c", alice));
+  @Test
+  void 타인의_글_삭제_시도면_403이고_원본이_남아있다() throws Exception {
+    Post saved = postRepository.save(new Post("t", "c", alice));
 
-        mockMvc.perform(delete("/api/posts/" + saved.getId())
-                        .header("Authorization", bobToken))
-                .andExpect(status().isForbidden());
+    mockMvc
+        .perform(delete("/api/posts/" + saved.getId()).header("Authorization", bobToken))
+        .andExpect(status().isForbidden());
 
-        assertThat(postRepository.findById(saved.getId())).isPresent();
-    }
+    assertThat(postRepository.findById(saved.getId())).isPresent();
+  }
 
-    // -------- Resource state (404) --------
+  // -------- Resource state (404) --------
 
-    @Test
-    void 없는_id_단건조회면_404() throws Exception {
-        mockMvc.perform(get("/api/posts/9999"))
-                .andExpect(status().isNotFound())
-                .andExpect(jsonPath("$.status").value(404));
-    }
+  @Test
+  void 없는_id_단건조회면_404() throws Exception {
+    mockMvc
+        .perform(get("/api/posts/9999"))
+        .andExpect(status().isNotFound())
+        .andExpect(jsonPath("$.status").value(404));
+  }
 
-    @Test
-    void 없는_id_수정이면_404() throws Exception {
-        mockMvc.perform(put("/api/posts/9999")
-                        .header("Authorization", aliceToken)
-                        .contentType(MediaType.APPLICATION_JSON)
-                        .content("{\"title\":\"t\",\"content\":\"c\"}"))
-                .andExpect(status().isNotFound());
-    }
+  @Test
+  void 없는_id_수정이면_404() throws Exception {
+    mockMvc
+        .perform(
+            put("/api/posts/9999")
+                .header("Authorization", aliceToken)
+                .contentType(MediaType.APPLICATION_JSON)
+                .content("{\"title\":\"t\",\"content\":\"c\"}"))
+        .andExpect(status().isNotFound());
+  }
 
-    @Test
-    void 없는_id_삭제면_404() throws Exception {
-        mockMvc.perform(delete("/api/posts/9999")
-                        .header("Authorization", aliceToken))
-                .andExpect(status().isNotFound());
-    }
+  @Test
+  void 없는_id_삭제면_404() throws Exception {
+    mockMvc
+        .perform(delete("/api/posts/9999").header("Authorization", aliceToken))
+        .andExpect(status().isNotFound());
+  }
 
-    @Test
-    void 이미_삭제된_글_재삭제면_404() throws Exception {
-        Post saved = postRepository.save(new Post("t", "c", alice));
+  @Test
+  void 이미_삭제된_글_재삭제면_404() throws Exception {
+    Post saved = postRepository.save(new Post("t", "c", alice));
 
-        mockMvc.perform(delete("/api/posts/" + saved.getId())
-                        .header("Authorization", aliceToken))
-                .andExpect(status().isNoContent());
+    mockMvc
+        .perform(delete("/api/posts/" + saved.getId()).header("Authorization", aliceToken))
+        .andExpect(status().isNoContent());
 
-        mockMvc.perform(delete("/api/posts/" + saved.getId())
-                        .header("Authorization", aliceToken))
-                .andExpect(status().isNotFound());
-    }
+    mockMvc
+        .perform(delete("/api/posts/" + saved.getId()).header("Authorization", aliceToken))
+        .andExpect(status().isNotFound());
+  }
 }

--- a/src/test/java/com/example/board/post/PostListControllerTest.java
+++ b/src/test/java/com/example/board/post/PostListControllerTest.java
@@ -21,140 +21,144 @@ import org.springframework.test.web.servlet.MockMvc;
 @ActiveProfiles("test")
 class PostListControllerTest {
 
-    @Autowired
-    MockMvc mockMvc;
+  @Autowired MockMvc mockMvc;
 
-    @Autowired
-    PostRepository postRepository;
+  @Autowired PostRepository postRepository;
 
-    @Autowired
-    UserRepository userRepository;
+  @Autowired UserRepository userRepository;
 
-    @Autowired
-    PasswordEncoder passwordEncoder;
+  @Autowired PasswordEncoder passwordEncoder;
 
-    User alice;
+  User alice;
 
-    @BeforeEach
-    void setUp() {
-        postRepository.deleteAll();
-        userRepository.deleteAll();
-        alice = userRepository.save(new User("alice", passwordEncoder.encode("pw12345")));
+  @BeforeEach
+  void setUp() {
+    postRepository.deleteAll();
+    userRepository.deleteAll();
+    alice = userRepository.save(new User("alice", passwordEncoder.encode("pw12345")));
+  }
+
+  @AfterEach
+  void tearDown() {
+    postRepository.deleteAll();
+    userRepository.deleteAll();
+  }
+
+  @Test
+  void GET_목록은_인증없이_200이며_content는_배열이다() throws Exception {
+    mockMvc
+        .perform(get("/api/posts"))
+        .andExpect(status().isOk())
+        .andExpect(jsonPath("$.content").isArray())
+        .andExpect(jsonPath("$.page").value(0))
+        .andExpect(jsonPath("$.size").value(10));
+  }
+
+  @Test
+  void 빈_목록이면_content는_빈배열이고_totalElements_0_totalPages_0이다() throws Exception {
+    mockMvc
+        .perform(get("/api/posts"))
+        .andExpect(status().isOk())
+        .andExpect(jsonPath("$.content").isEmpty())
+        .andExpect(jsonPath("$.totalElements").value(0))
+        .andExpect(jsonPath("$.totalPages").value(0));
+  }
+
+  @Test
+  void 여러_글을_저장하면_최신순으로_정렬된다() throws Exception {
+    postRepository.save(new Post("old", "first", alice));
+    Thread.sleep(10);
+    postRepository.save(new Post("mid", "second", alice));
+    Thread.sleep(10);
+    Post latest = postRepository.save(new Post("new", "third", alice));
+
+    mockMvc
+        .perform(get("/api/posts"))
+        .andExpect(status().isOk())
+        .andExpect(jsonPath("$.totalElements").value(3))
+        .andExpect(jsonPath("$.content[0].id").value(latest.getId()))
+        .andExpect(jsonPath("$.content[0].title").value("new"));
+  }
+
+  @Test
+  void 파라미터_없이_호출하면_page0_size10으로_동작한다() throws Exception {
+    for (int i = 0; i < 15; i++) {
+      postRepository.save(new Post("t" + i, "c" + i, alice));
     }
 
-    @AfterEach
-    void tearDown() {
-        postRepository.deleteAll();
-        userRepository.deleteAll();
+    mockMvc
+        .perform(get("/api/posts"))
+        .andExpect(status().isOk())
+        .andExpect(jsonPath("$.page").value(0))
+        .andExpect(jsonPath("$.size").value(10))
+        .andExpect(jsonPath("$.totalElements").value(15))
+        .andExpect(jsonPath("$.totalPages").value(2))
+        .andExpect(jsonPath("$.content.length()").value(10));
+  }
+
+  @Test
+  void page1_size5로_조회하면_두번째_페이지가_5건_반환된다() throws Exception {
+    for (int i = 0; i < 15; i++) {
+      postRepository.save(new Post("t" + i, "c" + i, alice));
     }
 
-    @Test
-    void GET_목록은_인증없이_200이며_content는_배열이다() throws Exception {
-        mockMvc.perform(get("/api/posts"))
-                .andExpect(status().isOk())
-                .andExpect(jsonPath("$.content").isArray())
-                .andExpect(jsonPath("$.page").value(0))
-                .andExpect(jsonPath("$.size").value(10));
+    mockMvc
+        .perform(get("/api/posts").param("page", "1").param("size", "5"))
+        .andExpect(status().isOk())
+        .andExpect(jsonPath("$.page").value(1))
+        .andExpect(jsonPath("$.size").value(5))
+        .andExpect(jsonPath("$.totalElements").value(15))
+        .andExpect(jsonPath("$.totalPages").value(3))
+        .andExpect(jsonPath("$.content.length()").value(5));
+  }
+
+  @Test
+  void 페이지_범위_밖이면_빈_content와_올바른_totalPages를_반환한다() throws Exception {
+    for (int i = 0; i < 3; i++) {
+      postRepository.save(new Post("t" + i, "c" + i, alice));
     }
 
-    @Test
-    void 빈_목록이면_content는_빈배열이고_totalElements_0_totalPages_0이다() throws Exception {
-        mockMvc.perform(get("/api/posts"))
-                .andExpect(status().isOk())
-                .andExpect(jsonPath("$.content").isEmpty())
-                .andExpect(jsonPath("$.totalElements").value(0))
-                .andExpect(jsonPath("$.totalPages").value(0));
-    }
+    mockMvc
+        .perform(get("/api/posts").param("page", "5").param("size", "10"))
+        .andExpect(status().isOk())
+        .andExpect(jsonPath("$.content").isEmpty())
+        .andExpect(jsonPath("$.totalElements").value(3))
+        .andExpect(jsonPath("$.totalPages").value(1));
+  }
 
-    @Test
-    void 여러_글을_저장하면_최신순으로_정렬된다() throws Exception {
-        postRepository.save(new Post("old", "first", alice));
-        Thread.sleep(10);
-        postRepository.save(new Post("mid", "second", alice));
-        Thread.sleep(10);
-        Post latest = postRepository.save(new Post("new", "third", alice));
+  @Test
+  void size가_0이면_400을_반환한다() throws Exception {
+    mockMvc
+        .perform(get("/api/posts").param("size", "0"))
+        .andExpect(status().isBadRequest())
+        .andExpect(jsonPath("$.status").value(400));
+  }
 
-        mockMvc.perform(get("/api/posts"))
-                .andExpect(status().isOk())
-                .andExpect(jsonPath("$.totalElements").value(3))
-                .andExpect(jsonPath("$.content[0].id").value(latest.getId()))
-                .andExpect(jsonPath("$.content[0].title").value("new"));
-    }
+  @Test
+  void size가_음수면_400을_반환한다() throws Exception {
+    mockMvc.perform(get("/api/posts").param("size", "-1")).andExpect(status().isBadRequest());
+  }
 
-    @Test
-    void 파라미터_없이_호출하면_page0_size10으로_동작한다() throws Exception {
-        for (int i = 0; i < 15; i++) {
-            postRepository.save(new Post("t" + i, "c" + i, alice));
-        }
+  @Test
+  void page가_음수면_400을_반환한다() throws Exception {
+    mockMvc
+        .perform(get("/api/posts").param("page", "-1"))
+        .andExpect(status().isBadRequest())
+        .andExpect(jsonPath("$.status").value(400));
+  }
 
-        mockMvc.perform(get("/api/posts"))
-                .andExpect(status().isOk())
-                .andExpect(jsonPath("$.page").value(0))
-                .andExpect(jsonPath("$.size").value(10))
-                .andExpect(jsonPath("$.totalElements").value(15))
-                .andExpect(jsonPath("$.totalPages").value(2))
-                .andExpect(jsonPath("$.content.length()").value(10));
-    }
+  @Test
+  void 목록_응답_항목은_id_title_content_authorUsername_createdAt_updatedAt을_포함한다() throws Exception {
+    postRepository.save(new Post("hello", "world", alice));
 
-    @Test
-    void page1_size5로_조회하면_두번째_페이지가_5건_반환된다() throws Exception {
-        for (int i = 0; i < 15; i++) {
-            postRepository.save(new Post("t" + i, "c" + i, alice));
-        }
-
-        mockMvc.perform(get("/api/posts").param("page", "1").param("size", "5"))
-                .andExpect(status().isOk())
-                .andExpect(jsonPath("$.page").value(1))
-                .andExpect(jsonPath("$.size").value(5))
-                .andExpect(jsonPath("$.totalElements").value(15))
-                .andExpect(jsonPath("$.totalPages").value(3))
-                .andExpect(jsonPath("$.content.length()").value(5));
-    }
-
-    @Test
-    void 페이지_범위_밖이면_빈_content와_올바른_totalPages를_반환한다() throws Exception {
-        for (int i = 0; i < 3; i++) {
-            postRepository.save(new Post("t" + i, "c" + i, alice));
-        }
-
-        mockMvc.perform(get("/api/posts").param("page", "5").param("size", "10"))
-                .andExpect(status().isOk())
-                .andExpect(jsonPath("$.content").isEmpty())
-                .andExpect(jsonPath("$.totalElements").value(3))
-                .andExpect(jsonPath("$.totalPages").value(1));
-    }
-
-    @Test
-    void size가_0이면_400을_반환한다() throws Exception {
-        mockMvc.perform(get("/api/posts").param("size", "0"))
-                .andExpect(status().isBadRequest())
-                .andExpect(jsonPath("$.status").value(400));
-    }
-
-    @Test
-    void size가_음수면_400을_반환한다() throws Exception {
-        mockMvc.perform(get("/api/posts").param("size", "-1"))
-                .andExpect(status().isBadRequest());
-    }
-
-    @Test
-    void page가_음수면_400을_반환한다() throws Exception {
-        mockMvc.perform(get("/api/posts").param("page", "-1"))
-                .andExpect(status().isBadRequest())
-                .andExpect(jsonPath("$.status").value(400));
-    }
-
-    @Test
-    void 목록_응답_항목은_id_title_content_authorUsername_createdAt_updatedAt을_포함한다() throws Exception {
-        postRepository.save(new Post("hello", "world", alice));
-
-        mockMvc.perform(get("/api/posts"))
-                .andExpect(status().isOk())
-                .andExpect(jsonPath("$.content[0].id").isNumber())
-                .andExpect(jsonPath("$.content[0].title").value("hello"))
-                .andExpect(jsonPath("$.content[0].content").value("world"))
-                .andExpect(jsonPath("$.content[0].authorUsername").value("alice"))
-                .andExpect(jsonPath("$.content[0].createdAt").exists())
-                .andExpect(jsonPath("$.content[0].updatedAt").exists());
-    }
+    mockMvc
+        .perform(get("/api/posts"))
+        .andExpect(status().isOk())
+        .andExpect(jsonPath("$.content[0].id").isNumber())
+        .andExpect(jsonPath("$.content[0].title").value("hello"))
+        .andExpect(jsonPath("$.content[0].content").value("world"))
+        .andExpect(jsonPath("$.content[0].authorUsername").value("alice"))
+        .andExpect(jsonPath("$.content[0].createdAt").exists())
+        .andExpect(jsonPath("$.content[0].updatedAt").exists());
+  }
 }

--- a/src/test/java/com/example/board/security/CustomUserDetailsServiceTest.java
+++ b/src/test/java/com/example/board/security/CustomUserDetailsServiceTest.java
@@ -18,36 +18,33 @@ import org.springframework.test.context.ActiveProfiles;
 @ActiveProfiles("test")
 class CustomUserDetailsServiceTest {
 
-    @Autowired
-    CustomUserDetailsService customUserDetailsService;
+  @Autowired CustomUserDetailsService customUserDetailsService;
 
-    @Autowired
-    UserRepository userRepository;
+  @Autowired UserRepository userRepository;
 
-    @Autowired
-    PasswordEncoder passwordEncoder;
+  @Autowired PasswordEncoder passwordEncoder;
 
-    @BeforeEach
-    void cleanDb() {
-        userRepository.deleteAll();
-    }
+  @BeforeEach
+  void cleanDb() {
+    userRepository.deleteAll();
+  }
 
-    @Test
-    void loadUserByUsername_존재하는_사용자면_저장된_username과_해시된_password를_담은_UserDetails를_반환한다() {
-        String hashed = passwordEncoder.encode("pw12345");
-        userRepository.save(new User("uds_alice", hashed));
+  @Test
+  void loadUserByUsername_존재하는_사용자면_저장된_username과_해시된_password를_담은_UserDetails를_반환한다() {
+    String hashed = passwordEncoder.encode("pw12345");
+    userRepository.save(new User("uds_alice", hashed));
 
-        UserDetails details = customUserDetailsService.loadUserByUsername("uds_alice");
+    UserDetails details = customUserDetailsService.loadUserByUsername("uds_alice");
 
-        assertThat(details.getUsername()).isEqualTo("uds_alice");
-        assertThat(details.getPassword()).isEqualTo(hashed);
-        assertThat(details.getAuthorities()).isEmpty();
-    }
+    assertThat(details.getUsername()).isEqualTo("uds_alice");
+    assertThat(details.getPassword()).isEqualTo(hashed);
+    assertThat(details.getAuthorities()).isEmpty();
+  }
 
-    @Test
-    void loadUserByUsername_미존재_username이면_UsernameNotFoundException이_발생한다() {
-        assertThatThrownBy(() -> customUserDetailsService.loadUserByUsername("uds_nobody"))
-                .isInstanceOf(UsernameNotFoundException.class)
-                .hasMessageContaining("uds_nobody");
-    }
+  @Test
+  void loadUserByUsername_미존재_username이면_UsernameNotFoundException이_발생한다() {
+    assertThatThrownBy(() -> customUserDetailsService.loadUserByUsername("uds_nobody"))
+        .isInstanceOf(UsernameNotFoundException.class)
+        .hasMessageContaining("uds_nobody");
+  }
 }

--- a/src/test/java/com/example/board/user/AuthServiceTest.java
+++ b/src/test/java/com/example/board/user/AuthServiceTest.java
@@ -15,88 +15,85 @@ import org.springframework.test.context.ActiveProfiles;
 @ActiveProfiles("test")
 class AuthServiceTest {
 
-    @Autowired
-    AuthService authService;
+  @Autowired AuthService authService;
 
-    @Autowired
-    UserRepository userRepository;
+  @Autowired UserRepository userRepository;
 
-    @Autowired
-    JwtTokenProvider jwtTokenProvider;
+  @Autowired JwtTokenProvider jwtTokenProvider;
 
-    @BeforeEach
-    void cleanDb() {
-        userRepository.deleteAll();
-    }
+  @BeforeEach
+  void cleanDb() {
+    userRepository.deleteAll();
+  }
 
-    @Test
-    void signup_정상입력시_User를_저장하고_password는_해시된다() {
-        User saved = authService.signup(new SignupRequest("alice_srv", "pw12345"));
+  @Test
+  void signup_정상입력시_User를_저장하고_password는_해시된다() {
+    User saved = authService.signup(new SignupRequest("alice_srv", "pw12345"));
 
-        assertThat(saved.getId()).isNotNull();
-        assertThat(saved.getUsername()).isEqualTo("alice_srv");
-        assertThat(saved.getPassword()).isNotEqualTo("pw12345");
-        assertThat(saved.getPassword()).startsWith("$2");
-    }
+    assertThat(saved.getId()).isNotNull();
+    assertThat(saved.getUsername()).isEqualTo("alice_srv");
+    assertThat(saved.getPassword()).isNotEqualTo("pw12345");
+    assertThat(saved.getPassword()).startsWith("$2");
+  }
 
-    @Test
-    void signup_username이_null이면_IllegalArgumentException이_발생한다() {
-        SignupRequest request = new SignupRequest(null, "pw12345");
+  @Test
+  void signup_username이_null이면_IllegalArgumentException이_발생한다() {
+    SignupRequest request = new SignupRequest(null, "pw12345");
 
-        assertThatThrownBy(() -> authService.signup(request))
-                .isInstanceOf(IllegalArgumentException.class)
-                .hasMessageContaining("필수");
-    }
+    assertThatThrownBy(() -> authService.signup(request))
+        .isInstanceOf(IllegalArgumentException.class)
+        .hasMessageContaining("필수");
+  }
 
-    @Test
-    void signup_username이_공백만이면_trim_후_IllegalArgumentException이_발생한다() {
-        SignupRequest request = new SignupRequest("   ", "pw12345");
+  @Test
+  void signup_username이_공백만이면_trim_후_IllegalArgumentException이_발생한다() {
+    SignupRequest request = new SignupRequest("   ", "pw12345");
 
-        assertThatThrownBy(() -> authService.signup(request))
-                .isInstanceOf(IllegalArgumentException.class)
-                .hasMessageContaining("필수");
-    }
+    assertThatThrownBy(() -> authService.signup(request))
+        .isInstanceOf(IllegalArgumentException.class)
+        .hasMessageContaining("필수");
+  }
 
-    @Test
-    void signup_동일한_username이면_중복_메시지와_함께_IllegalArgumentException이_발생한다() {
-        authService.signup(new SignupRequest("dup_srv", "pw12345"));
+  @Test
+  void signup_동일한_username이면_중복_메시지와_함께_IllegalArgumentException이_발생한다() {
+    authService.signup(new SignupRequest("dup_srv", "pw12345"));
 
-        assertThatThrownBy(() -> authService.signup(new SignupRequest("dup_srv", "other99")))
-                .isInstanceOf(IllegalArgumentException.class)
-                .hasMessageContaining("이미")
-                .hasMessageContaining("dup_srv");
-    }
+    assertThatThrownBy(() -> authService.signup(new SignupRequest("dup_srv", "other99")))
+        .isInstanceOf(IllegalArgumentException.class)
+        .hasMessageContaining("이미")
+        .hasMessageContaining("dup_srv");
+  }
 
-    @Test
-    void signup_username이_trim되어_저장된다() {
-        User saved = authService.signup(new SignupRequest("  alice_trim  ", "pw12345"));
+  @Test
+  void signup_username이_trim되어_저장된다() {
+    User saved = authService.signup(new SignupRequest("  alice_trim  ", "pw12345"));
 
-        assertThat(saved.getUsername()).isEqualTo("alice_trim");
-    }
+    assertThat(saved.getUsername()).isEqualTo("alice_trim");
+  }
 
-    @Test
-    void login_정상입력시_TokenResponse의_accessToken_tokenType_expiresIn이_채워진다() {
-        authService.signup(new SignupRequest("login_ok", "pw12345"));
+  @Test
+  void login_정상입력시_TokenResponse의_accessToken_tokenType_expiresIn이_채워진다() {
+    authService.signup(new SignupRequest("login_ok", "pw12345"));
 
-        TokenResponse token = authService.login(new LoginRequest("login_ok", "pw12345"));
+    TokenResponse token = authService.login(new LoginRequest("login_ok", "pw12345"));
 
-        assertThat(token.accessToken()).isNotBlank();
-        assertThat(token.tokenType()).isEqualTo("Bearer");
-        assertThat(token.expiresIn()).isEqualTo(jwtTokenProvider.getExpirationMs() / 1000);
-        assertThat(jwtTokenProvider.resolveUsername(token.accessToken())).contains("login_ok");
-    }
+    assertThat(token.accessToken()).isNotBlank();
+    assertThat(token.tokenType()).isEqualTo("Bearer");
+    assertThat(token.expiresIn()).isEqualTo(jwtTokenProvider.getExpirationMs() / 1000);
+    assertThat(jwtTokenProvider.resolveUsername(token.accessToken())).contains("login_ok");
+  }
 
-    @Test
-    void login_잘못된_password면_AuthenticationException이_발생한다() {
-        authService.signup(new SignupRequest("login_badpw", "pw12345"));
+  @Test
+  void login_잘못된_password면_AuthenticationException이_발생한다() {
+    authService.signup(new SignupRequest("login_badpw", "pw12345"));
 
-        assertThatThrownBy(() -> authService.login(new LoginRequest("login_badpw", "wrong-password")))
-                .isInstanceOf(AuthenticationException.class);
-    }
+    assertThatThrownBy(() -> authService.login(new LoginRequest("login_badpw", "wrong-password")))
+        .isInstanceOf(AuthenticationException.class);
+  }
 
-    @Test
-    void login_존재하지_않는_username이면_AuthenticationException이_발생한다() {
-        assertThatThrownBy(() -> authService.login(new LoginRequest("nobody_srv", "pw12345")))
-                .isInstanceOf(AuthenticationException.class);
-    }
+  @Test
+  void login_존재하지_않는_username이면_AuthenticationException이_발생한다() {
+    assertThatThrownBy(() -> authService.login(new LoginRequest("nobody_srv", "pw12345")))
+        .isInstanceOf(AuthenticationException.class);
+  }
 }

--- a/src/test/java/com/example/board/user/LoginControllerTest.java
+++ b/src/test/java/com/example/board/user/LoginControllerTest.java
@@ -38,263 +38,287 @@ import org.springframework.web.bind.annotation.RestController;
 @Import(LoginControllerTest.ProbeController.class)
 class LoginControllerTest {
 
-    @Autowired
-    MockMvc mockMvc;
+  @Autowired MockMvc mockMvc;
 
-    @Autowired
-    UserRepository userRepository;
+  @Autowired UserRepository userRepository;
 
-    @Autowired
-    PasswordEncoder passwordEncoder;
+  @Autowired PasswordEncoder passwordEncoder;
 
-    @Autowired
-    JwtTokenProvider jwtTokenProvider;
+  @Autowired JwtTokenProvider jwtTokenProvider;
 
-    @Value("${app.jwt.secret}")
-    String jwtSecret;
+  @Value("${app.jwt.secret}")
+  String jwtSecret;
 
-    @BeforeEach
-    void setUp() {
-        userRepository.deleteAll();
-        userRepository.save(new User("alice", passwordEncoder.encode("pw12345")));
+  @BeforeEach
+  void setUp() {
+    userRepository.deleteAll();
+    userRepository.save(new User("alice", passwordEncoder.encode("pw12345")));
+  }
+
+  @RestController
+  static class ProbeController {
+    @GetMapping("/api/probe/me")
+    public Map<String, Object> me(Authentication authentication) {
+      return Map.of("username", authentication.getName());
+    }
+  }
+
+  @Nested
+  class RestApi {
+
+    @Test
+    void 로그인_성공시_200과_accessToken_tokenType_expiresIn을_반환한다() throws Exception {
+      mockMvc
+          .perform(
+              post("/api/auth/login")
+                  .contentType(MediaType.APPLICATION_JSON)
+                  .content("{\"username\":\"alice\",\"password\":\"pw12345\"}"))
+          .andExpect(status().isOk())
+          .andExpect(jsonPath("$.accessToken").isString())
+          .andExpect(jsonPath("$.tokenType").value("Bearer"))
+          .andExpect(jsonPath("$.expiresIn").isNumber());
     }
 
-    @RestController
-    static class ProbeController {
-        @GetMapping("/probe/me")
-        public Map<String, Object> me(Authentication authentication) {
-            return Map.of("username", authentication.getName());
-        }
+    @Test
+    void 잘못된_password면_401과_ErrorResponse_본문을_반환한다() throws Exception {
+      mockMvc
+          .perform(
+              post("/api/auth/login")
+                  .contentType(MediaType.APPLICATION_JSON)
+                  .content("{\"username\":\"alice\",\"password\":\"wrong-password\"}"))
+          .andExpect(status().isUnauthorized())
+          .andExpect(jsonPath("$.status").value(401))
+          .andExpect(jsonPath("$.error").value("Unauthorized"))
+          .andExpect(jsonPath("$.message").exists())
+          .andExpect(jsonPath("$.path").value("/api/auth/login"));
     }
 
-    @Nested
-    class RestApi {
-
-        @Test
-        void 로그인_성공시_200과_accessToken_tokenType_expiresIn을_반환한다() throws Exception {
-            mockMvc.perform(post("/api/auth/login")
-                            .contentType(MediaType.APPLICATION_JSON)
-                            .content("{\"username\":\"alice\",\"password\":\"pw12345\"}"))
-                    .andExpect(status().isOk())
-                    .andExpect(jsonPath("$.accessToken").isString())
-                    .andExpect(jsonPath("$.tokenType").value("Bearer"))
-                    .andExpect(jsonPath("$.expiresIn").isNumber());
-        }
-
-        @Test
-        void 잘못된_password면_401과_ErrorResponse_본문을_반환한다() throws Exception {
-            mockMvc.perform(post("/api/auth/login")
-                            .contentType(MediaType.APPLICATION_JSON)
-                            .content("{\"username\":\"alice\",\"password\":\"wrong-password\"}"))
-                    .andExpect(status().isUnauthorized())
-                    .andExpect(jsonPath("$.status").value(401))
-                    .andExpect(jsonPath("$.error").value("Unauthorized"))
-                    .andExpect(jsonPath("$.message").exists())
-                    .andExpect(jsonPath("$.path").value("/api/auth/login"));
-        }
-
-        @Test
-        void 존재하지_않는_username이면_401을_반환한다() throws Exception {
-            mockMvc.perform(post("/api/auth/login")
-                            .contentType(MediaType.APPLICATION_JSON)
-                            .content("{\"username\":\"nobody\",\"password\":\"pw12345\"}"))
-                    .andExpect(status().isUnauthorized());
-        }
-
-        @Test
-        void username이_null이면_400을_반환하고_필드명을_포함한다() throws Exception {
-            mockMvc.perform(post("/api/auth/login")
-                            .contentType(MediaType.APPLICATION_JSON)
-                            .content("{\"password\":\"pw12345\"}"))
-                    .andExpect(status().isBadRequest())
-                    .andExpect(jsonPath("$.message").value(containsString("username")));
-        }
-
-        @Test
-        void password가_null이면_400을_반환하고_필드명을_포함한다() throws Exception {
-            mockMvc.perform(post("/api/auth/login")
-                            .contentType(MediaType.APPLICATION_JSON)
-                            .content("{\"username\":\"alice\"}"))
-                    .andExpect(status().isBadRequest())
-                    .andExpect(jsonPath("$.message").value(containsString("password")));
-        }
-
-        @Test
-        void username이_빈문자열이면_400을_반환한다() throws Exception {
-            mockMvc.perform(post("/api/auth/login")
-                            .contentType(MediaType.APPLICATION_JSON)
-                            .content("{\"username\":\"\",\"password\":\"pw12345\"}"))
-                    .andExpect(status().isBadRequest());
-        }
-
-        @Test
-        void password가_빈문자열이면_400을_반환한다() throws Exception {
-            mockMvc.perform(post("/api/auth/login")
-                            .contentType(MediaType.APPLICATION_JSON)
-                            .content("{\"username\":\"alice\",\"password\":\"\"}"))
-                    .andExpect(status().isBadRequest());
-        }
-
-        @Test
-        void username이_공백만이면_400을_반환하고_필드명을_포함한다() throws Exception {
-            mockMvc.perform(post("/api/auth/login")
-                            .contentType(MediaType.APPLICATION_JSON)
-                            .content("{\"username\":\"   \",\"password\":\"pw12345\"}"))
-                    .andExpect(status().isBadRequest())
-                    .andExpect(jsonPath("$.message").value(containsString("username")));
-        }
+    @Test
+    void 존재하지_않는_username이면_401을_반환한다() throws Exception {
+      mockMvc
+          .perform(
+              post("/api/auth/login")
+                  .contentType(MediaType.APPLICATION_JSON)
+                  .content("{\"username\":\"nobody\",\"password\":\"pw12345\"}"))
+          .andExpect(status().isUnauthorized());
     }
 
-    @Nested
-    class JwtFilter {
-
-        @Test
-        void 유효한_Bearer_토큰으로_보호엔드포인트_호출시_200과_username이_반환된다() throws Exception {
-            String token = jwtTokenProvider.generateToken("alice");
-            mockMvc.perform(get("/probe/me")
-                            .header("Authorization", "Bearer " + token))
-                    .andExpect(status().isOk())
-                    .andExpect(jsonPath("$.username").value("alice"));
-        }
-
-        @Test
-        void 토큰없이_보호엔드포인트_호출시_401이_반환된다() throws Exception {
-            mockMvc.perform(get("/probe/me"))
-                    .andExpect(status().isUnauthorized());
-        }
-
-        @Test
-        void Bearer_접두어_없이_토큰만_보내면_401이_반환된다() throws Exception {
-            String token = jwtTokenProvider.generateToken("alice");
-            mockMvc.perform(get("/probe/me")
-                            .header("Authorization", token))
-                    .andExpect(status().isUnauthorized());
-        }
-
-        @Test
-        void 변조된_토큰으로_호출시_401이_반환된다() throws Exception {
-            String token = jwtTokenProvider.generateToken("alice");
-            String tampered = token.substring(0, token.length() - 4) + "XXXX";
-            mockMvc.perform(get("/probe/me")
-                            .header("Authorization", "Bearer " + tampered))
-                    .andExpect(status().isUnauthorized());
-        }
-
-        @Test
-        void 만료된_토큰으로_호출시_401이_반환된다() throws Exception {
-            SecretKey key = Keys.hmacShaKeyFor(jwtSecret.getBytes(StandardCharsets.UTF_8));
-            Date past = new Date(System.currentTimeMillis() - 10_000);
-            String expiredToken = Jwts.builder()
-                    .subject("alice")
-                    .issuedAt(new Date(past.getTime() - 1000))
-                    .expiration(past)
-                    .signWith(key, Jwts.SIG.HS256)
-                    .compact();
-            mockMvc.perform(get("/probe/me")
-                            .header("Authorization", "Bearer " + expiredToken))
-                    .andExpect(status().isUnauthorized());
-        }
-
-        @Test
-        void 서명은_유효하지만_sub_claim이_없는_토큰으로_호출시_401이_반환된다() throws Exception {
-            SecretKey key = Keys.hmacShaKeyFor(jwtSecret.getBytes(StandardCharsets.UTF_8));
-            String noSubjectToken = Jwts.builder()
-                    .issuedAt(new Date())
-                    .expiration(new Date(System.currentTimeMillis() + 60_000))
-                    .signWith(key, Jwts.SIG.HS256)
-                    .compact();
-            mockMvc.perform(get("/probe/me")
-                            .header("Authorization", "Bearer " + noSubjectToken))
-                    .andExpect(status().isUnauthorized());
-        }
-
-        @Test
-        void 유효한_토큰이지만_사용자가_DB에서_삭제됐으면_401이_반환된다() throws Exception {
-            String token = jwtTokenProvider.generateToken("alice");
-            userRepository.deleteAll();
-            mockMvc.perform(get("/probe/me")
-                            .header("Authorization", "Bearer " + token))
-                    .andExpect(status().isUnauthorized());
-        }
-
-        @Test
-        void 다른_서명키로_만든_토큰으로_호출시_401이_반환된다() throws Exception {
-            String otherSecret = "different-secret-different-secret-different-secret-64bytes!!!!!";
-            SecretKey wrongKey = Keys.hmacShaKeyFor(otherSecret.getBytes(StandardCharsets.UTF_8));
-            String foreignToken = Jwts.builder()
-                    .subject("alice")
-                    .issuedAt(new Date())
-                    .expiration(new Date(System.currentTimeMillis() + 60_000))
-                    .signWith(wrongKey, Jwts.SIG.HS256)
-                    .compact();
-            mockMvc.perform(get("/probe/me")
-                            .header("Authorization", "Bearer " + foreignToken))
-                    .andExpect(status().isUnauthorized());
-        }
+    @Test
+    void username이_null이면_400을_반환하고_필드명을_포함한다() throws Exception {
+      mockMvc
+          .perform(
+              post("/api/auth/login")
+                  .contentType(MediaType.APPLICATION_JSON)
+                  .content("{\"password\":\"pw12345\"}"))
+          .andExpect(status().isBadRequest())
+          .andExpect(jsonPath("$.message").value(containsString("username")));
     }
 
-    @Nested
-    class View {
-
-        @Test
-        void GET_login은_로그인폼을_렌더한다() throws Exception {
-            mockMvc.perform(get("/login"))
-                    .andExpect(status().isOk())
-                    .andExpect(content().string(containsString("<form")))
-                    .andExpect(content().string(containsString("action=\"/login\"")))
-                    .andExpect(content().string(containsString("name=\"username\"")))
-                    .andExpect(content().string(containsString("name=\"password\"")))
-                    .andExpect(content().string(containsString("type=\"submit\"")));
-        }
-
-        @Test
-        void POST_login_정상입력시_302_redirect와_HttpOnly_accessToken_쿠키가_세팅된다() throws Exception {
-            mockMvc.perform(post("/login")
-                            .contentType(MediaType.APPLICATION_FORM_URLENCODED)
-                            .param("username", "alice")
-                            .param("password", "pw12345"))
-                    .andExpect(status().is3xxRedirection())
-                    .andExpect(header().string("Location", "/login?success=true"))
-                    .andExpect(cookie().exists("accessToken"))
-                    .andExpect(cookie().httpOnly("accessToken", true));
-        }
-
-        @Test
-        void POST_login_잘못된_password면_동일화면에_오류메시지가_렌더된다() throws Exception {
-            mockMvc.perform(post("/login")
-                            .contentType(MediaType.APPLICATION_FORM_URLENCODED)
-                            .param("username", "alice")
-                            .param("password", "wrong-password"))
-                    .andExpect(status().isOk())
-                    .andExpect(content().string(containsString("<form")))
-                    .andExpect(content().string(containsString("일치")));
-        }
-
-        @Test
-        void POST_login_존재하지_않는_username이면_동일화면에_오류메시지가_렌더된다() throws Exception {
-            mockMvc.perform(post("/login")
-                            .contentType(MediaType.APPLICATION_FORM_URLENCODED)
-                            .param("username", "nobody")
-                            .param("password", "pw12345"))
-                    .andExpect(status().isOk())
-                    .andExpect(content().string(containsString("<form")));
-        }
-
-        @Test
-        void POST_login_username_빈문자열이면_동일화면에_검증_오류가_렌더된다() throws Exception {
-            mockMvc.perform(post("/login")
-                            .contentType(MediaType.APPLICATION_FORM_URLENCODED)
-                            .param("username", "")
-                            .param("password", "pw12345"))
-                    .andExpect(status().isOk())
-                    .andExpect(content().string(containsString("username")));
-        }
-
-        @Test
-        void GET_login_success_파라미터시_성공메시지를_렌더한다() throws Exception {
-            mockMvc.perform(get("/login").param("success", "true"))
-                    .andExpect(status().isOk())
-                    .andExpect(content().string(containsString("로그인 성공")));
-        }
+    @Test
+    void password가_null이면_400을_반환하고_필드명을_포함한다() throws Exception {
+      mockMvc
+          .perform(
+              post("/api/auth/login")
+                  .contentType(MediaType.APPLICATION_JSON)
+                  .content("{\"username\":\"alice\"}"))
+          .andExpect(status().isBadRequest())
+          .andExpect(jsonPath("$.message").value(containsString("password")));
     }
+
+    @Test
+    void username이_빈문자열이면_400을_반환한다() throws Exception {
+      mockMvc
+          .perform(
+              post("/api/auth/login")
+                  .contentType(MediaType.APPLICATION_JSON)
+                  .content("{\"username\":\"\",\"password\":\"pw12345\"}"))
+          .andExpect(status().isBadRequest());
+    }
+
+    @Test
+    void password가_빈문자열이면_400을_반환한다() throws Exception {
+      mockMvc
+          .perform(
+              post("/api/auth/login")
+                  .contentType(MediaType.APPLICATION_JSON)
+                  .content("{\"username\":\"alice\",\"password\":\"\"}"))
+          .andExpect(status().isBadRequest());
+    }
+
+    @Test
+    void username이_공백만이면_400을_반환하고_필드명을_포함한다() throws Exception {
+      mockMvc
+          .perform(
+              post("/api/auth/login")
+                  .contentType(MediaType.APPLICATION_JSON)
+                  .content("{\"username\":\"   \",\"password\":\"pw12345\"}"))
+          .andExpect(status().isBadRequest())
+          .andExpect(jsonPath("$.message").value(containsString("username")));
+    }
+  }
+
+  @Nested
+  class JwtFilter {
+
+    @Test
+    void 유효한_Bearer_토큰으로_보호엔드포인트_호출시_200과_username이_반환된다() throws Exception {
+      String token = jwtTokenProvider.generateToken("alice");
+      mockMvc
+          .perform(get("/api/probe/me").header("Authorization", "Bearer " + token))
+          .andExpect(status().isOk())
+          .andExpect(jsonPath("$.username").value("alice"));
+    }
+
+    @Test
+    void 토큰없이_보호엔드포인트_호출시_401이_반환된다() throws Exception {
+      mockMvc.perform(get("/api/probe/me")).andExpect(status().isUnauthorized());
+    }
+
+    @Test
+    void Bearer_접두어_없이_토큰만_보내면_401이_반환된다() throws Exception {
+      String token = jwtTokenProvider.generateToken("alice");
+      mockMvc
+          .perform(get("/api/probe/me").header("Authorization", token))
+          .andExpect(status().isUnauthorized());
+    }
+
+    @Test
+    void 변조된_토큰으로_호출시_401이_반환된다() throws Exception {
+      String token = jwtTokenProvider.generateToken("alice");
+      String tampered = token.substring(0, token.length() - 4) + "XXXX";
+      mockMvc
+          .perform(get("/api/probe/me").header("Authorization", "Bearer " + tampered))
+          .andExpect(status().isUnauthorized());
+    }
+
+    @Test
+    void 만료된_토큰으로_호출시_401이_반환된다() throws Exception {
+      SecretKey key = Keys.hmacShaKeyFor(jwtSecret.getBytes(StandardCharsets.UTF_8));
+      Date past = new Date(System.currentTimeMillis() - 10_000);
+      String expiredToken =
+          Jwts.builder()
+              .subject("alice")
+              .issuedAt(new Date(past.getTime() - 1000))
+              .expiration(past)
+              .signWith(key, Jwts.SIG.HS256)
+              .compact();
+      mockMvc
+          .perform(get("/api/probe/me").header("Authorization", "Bearer " + expiredToken))
+          .andExpect(status().isUnauthorized());
+    }
+
+    @Test
+    void 서명은_유효하지만_sub_claim이_없는_토큰으로_호출시_401이_반환된다() throws Exception {
+      SecretKey key = Keys.hmacShaKeyFor(jwtSecret.getBytes(StandardCharsets.UTF_8));
+      String noSubjectToken =
+          Jwts.builder()
+              .issuedAt(new Date())
+              .expiration(new Date(System.currentTimeMillis() + 60_000))
+              .signWith(key, Jwts.SIG.HS256)
+              .compact();
+      mockMvc
+          .perform(get("/api/probe/me").header("Authorization", "Bearer " + noSubjectToken))
+          .andExpect(status().isUnauthorized());
+    }
+
+    @Test
+    void 유효한_토큰이지만_사용자가_DB에서_삭제됐으면_401이_반환된다() throws Exception {
+      String token = jwtTokenProvider.generateToken("alice");
+      userRepository.deleteAll();
+      mockMvc
+          .perform(get("/api/probe/me").header("Authorization", "Bearer " + token))
+          .andExpect(status().isUnauthorized());
+    }
+
+    @Test
+    void 다른_서명키로_만든_토큰으로_호출시_401이_반환된다() throws Exception {
+      String otherSecret = "different-secret-different-secret-different-secret-64bytes!!!!!";
+      SecretKey wrongKey = Keys.hmacShaKeyFor(otherSecret.getBytes(StandardCharsets.UTF_8));
+      String foreignToken =
+          Jwts.builder()
+              .subject("alice")
+              .issuedAt(new Date())
+              .expiration(new Date(System.currentTimeMillis() + 60_000))
+              .signWith(wrongKey, Jwts.SIG.HS256)
+              .compact();
+      mockMvc
+          .perform(get("/api/probe/me").header("Authorization", "Bearer " + foreignToken))
+          .andExpect(status().isUnauthorized());
+    }
+  }
+
+  @Nested
+  class View {
+
+    @Test
+    void GET_login은_로그인폼을_렌더한다() throws Exception {
+      mockMvc
+          .perform(get("/login"))
+          .andExpect(status().isOk())
+          .andExpect(content().string(containsString("<form")))
+          .andExpect(content().string(containsString("action=\"/login\"")))
+          .andExpect(content().string(containsString("name=\"username\"")))
+          .andExpect(content().string(containsString("name=\"password\"")))
+          .andExpect(content().string(containsString("type=\"submit\"")));
+    }
+
+    @Test
+    void POST_login_정상입력시_302_redirect와_HttpOnly_accessToken_쿠키가_세팅된다() throws Exception {
+      mockMvc
+          .perform(
+              post("/login")
+                  .contentType(MediaType.APPLICATION_FORM_URLENCODED)
+                  .param("username", "alice")
+                  .param("password", "pw12345"))
+          .andExpect(status().is3xxRedirection())
+          .andExpect(header().string("Location", "/login?success=true"))
+          .andExpect(cookie().exists("accessToken"))
+          .andExpect(cookie().httpOnly("accessToken", true));
+    }
+
+    @Test
+    void POST_login_잘못된_password면_동일화면에_오류메시지가_렌더된다() throws Exception {
+      mockMvc
+          .perform(
+              post("/login")
+                  .contentType(MediaType.APPLICATION_FORM_URLENCODED)
+                  .param("username", "alice")
+                  .param("password", "wrong-password"))
+          .andExpect(status().isOk())
+          .andExpect(content().string(containsString("<form")))
+          .andExpect(content().string(containsString("일치")));
+    }
+
+    @Test
+    void POST_login_존재하지_않는_username이면_동일화면에_오류메시지가_렌더된다() throws Exception {
+      mockMvc
+          .perform(
+              post("/login")
+                  .contentType(MediaType.APPLICATION_FORM_URLENCODED)
+                  .param("username", "nobody")
+                  .param("password", "pw12345"))
+          .andExpect(status().isOk())
+          .andExpect(content().string(containsString("<form")));
+    }
+
+    @Test
+    void POST_login_username_빈문자열이면_동일화면에_검증_오류가_렌더된다() throws Exception {
+      mockMvc
+          .perform(
+              post("/login")
+                  .contentType(MediaType.APPLICATION_FORM_URLENCODED)
+                  .param("username", "")
+                  .param("password", "pw12345"))
+          .andExpect(status().isOk())
+          .andExpect(content().string(containsString("username")));
+    }
+
+    @Test
+    void GET_login_success_파라미터시_성공메시지를_렌더한다() throws Exception {
+      mockMvc
+          .perform(get("/login").param("success", "true"))
+          .andExpect(status().isOk())
+          .andExpect(content().string(containsString("로그인 성공")));
+    }
+  }
 }

--- a/src/test/java/com/example/board/user/SignupControllerTest.java
+++ b/src/test/java/com/example/board/user/SignupControllerTest.java
@@ -25,173 +25,201 @@ import org.springframework.test.web.servlet.MockMvc;
 @ActiveProfiles("test")
 class SignupControllerTest {
 
-    @Autowired
-    MockMvc mockMvc;
+  @Autowired MockMvc mockMvc;
 
-    @Autowired
-    UserRepository userRepository;
+  @Autowired UserRepository userRepository;
 
-    @BeforeEach
-    void cleanDb() {
-        userRepository.deleteAll();
+  @BeforeEach
+  void cleanDb() {
+    userRepository.deleteAll();
+  }
+
+  @Nested
+  class RestApi {
+
+    @Test
+    void 회원가입_성공시_201과_id_username을_반환하고_password는_응답에_없다() throws Exception {
+      mockMvc
+          .perform(
+              post("/api/auth/signup")
+                  .contentType(MediaType.APPLICATION_JSON)
+                  .content("{\"username\":\"alice\",\"password\":\"pw12345\"}"))
+          .andExpect(status().isCreated())
+          .andExpect(jsonPath("$.id").exists())
+          .andExpect(jsonPath("$.username").value("alice"))
+          .andExpect(jsonPath("$.password").doesNotExist());
     }
 
-    @Nested
-    class RestApi {
+    @Test
+    void 저장된_password는_평문이_아닌_BCrypt_해시_형식이다() throws Exception {
+      mockMvc
+          .perform(
+              post("/api/auth/signup")
+                  .contentType(MediaType.APPLICATION_JSON)
+                  .content("{\"username\":\"bob\",\"password\":\"pw12345\"}"))
+          .andExpect(status().isCreated());
 
-        @Test
-        void 회원가입_성공시_201과_id_username을_반환하고_password는_응답에_없다() throws Exception {
-            mockMvc.perform(post("/api/auth/signup")
-                            .contentType(MediaType.APPLICATION_JSON)
-                            .content("{\"username\":\"alice\",\"password\":\"pw12345\"}"))
-                    .andExpect(status().isCreated())
-                    .andExpect(jsonPath("$.id").exists())
-                    .andExpect(jsonPath("$.username").value("alice"))
-                    .andExpect(jsonPath("$.password").doesNotExist());
-        }
-
-        @Test
-        void 저장된_password는_평문이_아닌_BCrypt_해시_형식이다() throws Exception {
-            mockMvc.perform(post("/api/auth/signup")
-                            .contentType(MediaType.APPLICATION_JSON)
-                            .content("{\"username\":\"bob\",\"password\":\"pw12345\"}"))
-                    .andExpect(status().isCreated());
-
-            User saved = userRepository.findByUsername("bob").orElseThrow();
-            assertThat(saved.getPassword()).isNotEqualTo("pw12345");
-            assertThat(saved.getPassword()).startsWith("$2");
-        }
-
-        @Test
-        void username이_null이면_400을_반환한다() throws Exception {
-            mockMvc.perform(post("/api/auth/signup")
-                            .contentType(MediaType.APPLICATION_JSON)
-                            .content("{\"password\":\"pw12345\"}"))
-                    .andExpect(status().isBadRequest())
-                    .andExpect(jsonPath("$.status").value(400));
-        }
-
-        @Test
-        void username이_빈문자열이면_400을_반환하고_필드명을_포함한다() throws Exception {
-            mockMvc.perform(post("/api/auth/signup")
-                            .contentType(MediaType.APPLICATION_JSON)
-                            .content("{\"username\":\"\",\"password\":\"pw12345\"}"))
-                    .andExpect(status().isBadRequest())
-                    .andExpect(jsonPath("$.message").value(containsString("username")));
-        }
-
-        @Test
-        void username이_공백만이면_400을_반환한다() throws Exception {
-            mockMvc.perform(post("/api/auth/signup")
-                            .contentType(MediaType.APPLICATION_JSON)
-                            .content("{\"username\":\"   \",\"password\":\"pw12345\"}"))
-                    .andExpect(status().isBadRequest());
-        }
-
-        @Test
-        void username이_2자면_400을_반환한다() throws Exception {
-            mockMvc.perform(post("/api/auth/signup")
-                            .contentType(MediaType.APPLICATION_JSON)
-                            .content("{\"username\":\"ab\",\"password\":\"pw12345\"}"))
-                    .andExpect(status().isBadRequest());
-        }
-
-        @Test
-        void username이_21자면_400을_반환한다() throws Exception {
-            mockMvc.perform(post("/api/auth/signup")
-                            .contentType(MediaType.APPLICATION_JSON)
-                            .content("{\"username\":\"a23456789012345678901\",\"password\":\"pw12345\"}"))
-                    .andExpect(status().isBadRequest());
-        }
-
-        @Test
-        void password가_null이면_400을_반환한다() throws Exception {
-            mockMvc.perform(post("/api/auth/signup")
-                            .contentType(MediaType.APPLICATION_JSON)
-                            .content("{\"username\":\"alice\"}"))
-                    .andExpect(status().isBadRequest())
-                    .andExpect(jsonPath("$.message").value(containsString("password")));
-        }
-
-        @Test
-        void password가_5자면_400을_반환한다() throws Exception {
-            mockMvc.perform(post("/api/auth/signup")
-                            .contentType(MediaType.APPLICATION_JSON)
-                            .content("{\"username\":\"alice\",\"password\":\"12345\"}"))
-                    .andExpect(status().isBadRequest());
-        }
-
-        @Test
-        void 동일_username으로_재가입하면_400과_중복_메시지를_반환한다() throws Exception {
-            mockMvc.perform(post("/api/auth/signup")
-                            .contentType(MediaType.APPLICATION_JSON)
-                            .content("{\"username\":\"dup\",\"password\":\"pw12345\"}"))
-                    .andExpect(status().isCreated());
-
-            mockMvc.perform(post("/api/auth/signup")
-                            .contentType(MediaType.APPLICATION_JSON)
-                            .content("{\"username\":\"dup\",\"password\":\"pw99999\"}"))
-                    .andExpect(status().isBadRequest())
-                    .andExpect(jsonPath("$.message").value(containsString("이미")));
-        }
+      User saved = userRepository.findByUsername("bob").orElseThrow();
+      assertThat(saved.getPassword()).isNotEqualTo("pw12345");
+      assertThat(saved.getPassword()).startsWith("$2");
     }
 
-    @Nested
-    class View {
-
-        @Test
-        void GET_signup은_회원가입_폼을_렌더한다() throws Exception {
-            mockMvc.perform(get("/signup"))
-                    .andExpect(status().isOk())
-                    .andExpect(content().string(containsString("<form")))
-                    .andExpect(content().string(containsString("action=\"/signup\"")))
-                    .andExpect(content().string(containsString("name=\"username\"")))
-                    .andExpect(content().string(containsString("name=\"password\"")))
-                    .andExpect(content().string(containsString("type=\"submit\"")));
-        }
-
-        @Test
-        void POST_signup_정상입력시_success_파라미터로_리다이렉트된다() throws Exception {
-            mockMvc.perform(post("/signup")
-                            .contentType(MediaType.APPLICATION_FORM_URLENCODED)
-                            .param("username", "charlie")
-                            .param("password", "pw12345"))
-                    .andExpect(status().is3xxRedirection())
-                    .andExpect(header().string("Location", "/signup?success=true"));
-        }
-
-        @Test
-        void GET_signup_success시_가입완료_메시지를_렌더한다() throws Exception {
-            mockMvc.perform(get("/signup").param("success", "true"))
-                    .andExpect(status().isOk())
-                    .andExpect(content().string(containsString("가입 완료")));
-        }
-
-        @Test
-        void POST_signup_중복_username이면_동일화면에_중복_오류가_렌더된다() throws Exception {
-            mockMvc.perform(post("/api/auth/signup")
-                            .contentType(MediaType.APPLICATION_JSON)
-                            .content("{\"username\":\"exists\",\"password\":\"pw12345\"}"))
-                    .andExpect(status().isCreated());
-
-            mockMvc.perform(post("/signup")
-                            .contentType(MediaType.APPLICATION_FORM_URLENCODED)
-                            .param("username", "exists")
-                            .param("password", "pw99999"))
-                    .andExpect(status().isOk())
-                    .andExpect(content().string(containsString("이미")));
-        }
-
-        @Test
-        void POST_signup_검증_실패시_동일화면에_오류_메시지가_렌더된다() throws Exception {
-            mockMvc.perform(post("/signup")
-                            .contentType(MediaType.APPLICATION_FORM_URLENCODED)
-                            .param("username", "")
-                            .param("password", "pw12345"))
-                    .andExpect(status().isOk())
-                    .andExpect(content().string(anyOf(
-                            containsString("username"),
-                            containsString("필수"))));
-        }
+    @Test
+    void username이_null이면_400을_반환한다() throws Exception {
+      mockMvc
+          .perform(
+              post("/api/auth/signup")
+                  .contentType(MediaType.APPLICATION_JSON)
+                  .content("{\"password\":\"pw12345\"}"))
+          .andExpect(status().isBadRequest())
+          .andExpect(jsonPath("$.status").value(400));
     }
+
+    @Test
+    void username이_빈문자열이면_400을_반환하고_필드명을_포함한다() throws Exception {
+      mockMvc
+          .perform(
+              post("/api/auth/signup")
+                  .contentType(MediaType.APPLICATION_JSON)
+                  .content("{\"username\":\"\",\"password\":\"pw12345\"}"))
+          .andExpect(status().isBadRequest())
+          .andExpect(jsonPath("$.message").value(containsString("username")));
+    }
+
+    @Test
+    void username이_공백만이면_400을_반환한다() throws Exception {
+      mockMvc
+          .perform(
+              post("/api/auth/signup")
+                  .contentType(MediaType.APPLICATION_JSON)
+                  .content("{\"username\":\"   \",\"password\":\"pw12345\"}"))
+          .andExpect(status().isBadRequest());
+    }
+
+    @Test
+    void username이_2자면_400을_반환한다() throws Exception {
+      mockMvc
+          .perform(
+              post("/api/auth/signup")
+                  .contentType(MediaType.APPLICATION_JSON)
+                  .content("{\"username\":\"ab\",\"password\":\"pw12345\"}"))
+          .andExpect(status().isBadRequest());
+    }
+
+    @Test
+    void username이_21자면_400을_반환한다() throws Exception {
+      mockMvc
+          .perform(
+              post("/api/auth/signup")
+                  .contentType(MediaType.APPLICATION_JSON)
+                  .content("{\"username\":\"a23456789012345678901\",\"password\":\"pw12345\"}"))
+          .andExpect(status().isBadRequest());
+    }
+
+    @Test
+    void password가_null이면_400을_반환한다() throws Exception {
+      mockMvc
+          .perform(
+              post("/api/auth/signup")
+                  .contentType(MediaType.APPLICATION_JSON)
+                  .content("{\"username\":\"alice\"}"))
+          .andExpect(status().isBadRequest())
+          .andExpect(jsonPath("$.message").value(containsString("password")));
+    }
+
+    @Test
+    void password가_5자면_400을_반환한다() throws Exception {
+      mockMvc
+          .perform(
+              post("/api/auth/signup")
+                  .contentType(MediaType.APPLICATION_JSON)
+                  .content("{\"username\":\"alice\",\"password\":\"12345\"}"))
+          .andExpect(status().isBadRequest());
+    }
+
+    @Test
+    void 동일_username으로_재가입하면_400과_중복_메시지를_반환한다() throws Exception {
+      mockMvc
+          .perform(
+              post("/api/auth/signup")
+                  .contentType(MediaType.APPLICATION_JSON)
+                  .content("{\"username\":\"dup\",\"password\":\"pw12345\"}"))
+          .andExpect(status().isCreated());
+
+      mockMvc
+          .perform(
+              post("/api/auth/signup")
+                  .contentType(MediaType.APPLICATION_JSON)
+                  .content("{\"username\":\"dup\",\"password\":\"pw99999\"}"))
+          .andExpect(status().isBadRequest())
+          .andExpect(jsonPath("$.message").value(containsString("이미")));
+    }
+  }
+
+  @Nested
+  class View {
+
+    @Test
+    void GET_signup은_회원가입_폼을_렌더한다() throws Exception {
+      mockMvc
+          .perform(get("/signup"))
+          .andExpect(status().isOk())
+          .andExpect(content().string(containsString("<form")))
+          .andExpect(content().string(containsString("action=\"/signup\"")))
+          .andExpect(content().string(containsString("name=\"username\"")))
+          .andExpect(content().string(containsString("name=\"password\"")))
+          .andExpect(content().string(containsString("type=\"submit\"")));
+    }
+
+    @Test
+    void POST_signup_정상입력시_success_파라미터로_리다이렉트된다() throws Exception {
+      mockMvc
+          .perform(
+              post("/signup")
+                  .contentType(MediaType.APPLICATION_FORM_URLENCODED)
+                  .param("username", "charlie")
+                  .param("password", "pw12345"))
+          .andExpect(status().is3xxRedirection())
+          .andExpect(header().string("Location", "/signup?success=true"));
+    }
+
+    @Test
+    void GET_signup_success시_가입완료_메시지를_렌더한다() throws Exception {
+      mockMvc
+          .perform(get("/signup").param("success", "true"))
+          .andExpect(status().isOk())
+          .andExpect(content().string(containsString("가입 완료")));
+    }
+
+    @Test
+    void POST_signup_중복_username이면_동일화면에_중복_오류가_렌더된다() throws Exception {
+      mockMvc
+          .perform(
+              post("/api/auth/signup")
+                  .contentType(MediaType.APPLICATION_JSON)
+                  .content("{\"username\":\"exists\",\"password\":\"pw12345\"}"))
+          .andExpect(status().isCreated());
+
+      mockMvc
+          .perform(
+              post("/signup")
+                  .contentType(MediaType.APPLICATION_FORM_URLENCODED)
+                  .param("username", "exists")
+                  .param("password", "pw99999"))
+          .andExpect(status().isOk())
+          .andExpect(content().string(containsString("이미")));
+    }
+
+    @Test
+    void POST_signup_검증_실패시_동일화면에_오류_메시지가_렌더된다() throws Exception {
+      mockMvc
+          .perform(
+              post("/signup")
+                  .contentType(MediaType.APPLICATION_FORM_URLENCODED)
+                  .param("username", "")
+                  .param("password", "pw12345"))
+          .andExpect(status().isOk())
+          .andExpect(content().string(anyOf(containsString("username"), containsString("필수"))));
+    }
+  }
 }

--- a/src/test/java/com/example/board/user/SignupPlaywrightTest.java
+++ b/src/test/java/com/example/board/user/SignupPlaywrightTest.java
@@ -17,29 +17,28 @@ import org.springframework.test.context.ActiveProfiles;
 @Tag("playwright")
 class SignupPlaywrightTest {
 
-    @LocalServerPort
-    int port;
+  @LocalServerPort int port;
 
-    @Test
-    void 브라우저로_회원가입_폼을_제출하면_성공_메시지가_표시된다() {
-        try (Playwright playwright = Playwright.create()) {
-            Browser browser = playwright.chromium()
-                    .launch(new BrowserType.LaunchOptions().setHeadless(true));
-            try {
-                Page page = browser.newPage();
-                page.navigate("http://localhost:" + port + "/signup");
+  @Test
+  void 브라우저로_회원가입_폼을_제출하면_성공_메시지가_표시된다() {
+    try (Playwright playwright = Playwright.create()) {
+      Browser browser =
+          playwright.chromium().launch(new BrowserType.LaunchOptions().setHeadless(true));
+      try {
+        Page page = browser.newPage();
+        page.navigate("http://localhost:" + port + "/signup");
 
-                page.fill("#username", "playwright_user");
-                page.fill("#password", "pw12345playwright");
-                page.click("button[type=submit]");
+        page.fill("#username", "playwright_user");
+        page.fill("#password", "pw12345playwright");
+        page.click("button[type=submit]");
 
-                page.waitForURL("**/signup?success=true");
+        page.waitForURL("**/signup?success=true");
 
-                assertThat(page.url()).contains("success=true");
-                assertThat(page.content()).contains("가입 완료");
-            } finally {
-                browser.close();
-            }
-        }
+        assertThat(page.url()).contains("success=true");
+        assertThat(page.content()).contains("가입 완료");
+      } finally {
+        browser.close();
+      }
     }
+  }
 }

--- a/src/test/java/com/example/board/user/SignupRequestTest.java
+++ b/src/test/java/com/example/board/user/SignupRequestTest.java
@@ -6,21 +6,21 @@ import org.junit.jupiter.api.Test;
 
 class SignupRequestTest {
 
-    @Test
-    void 인자_생성자로_필드가_세팅된다() {
-        SignupRequest request = new SignupRequest("alice", "pw12345");
+  @Test
+  void 인자_생성자로_필드가_세팅된다() {
+    SignupRequest request = new SignupRequest("alice", "pw12345");
 
-        assertThat(request.getUsername()).isEqualTo("alice");
-        assertThat(request.getPassword()).isEqualTo("pw12345");
-    }
+    assertThat(request.getUsername()).isEqualTo("alice");
+    assertThat(request.getPassword()).isEqualTo("pw12345");
+  }
 
-    @Test
-    void 기본_생성자_후_setter로_필드가_갱신된다() {
-        SignupRequest request = new SignupRequest();
-        request.setUsername("bob");
-        request.setPassword("pw99999");
+  @Test
+  void 기본_생성자_후_setter로_필드가_갱신된다() {
+    SignupRequest request = new SignupRequest();
+    request.setUsername("bob");
+    request.setPassword("pw99999");
 
-        assertThat(request.getUsername()).isEqualTo("bob");
-        assertThat(request.getPassword()).isEqualTo("pw99999");
-    }
+    assertThat(request.getUsername()).isEqualTo("bob");
+    assertThat(request.getPassword()).isEqualTo("pw99999");
+  }
 }


### PR DESCRIPTION
Closes #30

## Summary
- **`frontend/`에 Vite + React 18 + TypeScript 최소 앱 스캐폴딩** + Gradle(`com.github.node-gradle.node`)이 `./gradlew build` 한 번에 React 번들을 Spring jar 안 `static/`으로 포함하도록 배선.
- **SPA 폴백** — `WebMvcConfig`가 비-API GET 요청을 `forward:/index.html`로, `SecurityConfig`가 SPA 경로 `permitAll`. Thymeleaf · API · h2-console 회귀 없음.
- **`jacocoTestCoverageVerification` 통과** (98.66%, 1176/1192).

## 커밋 구조 (3 logical commits)

| 커밋 | 종류 | 파일 | 비고 |
|---|---|---|---|
| `e868a55` | chore | 36 | spotlessApply 사전 드리프트 정리 (코스메틱 only) + Checkstyle BoardApplication suppression |
| `9640a43` | feat | 13 | #30 본 구현 (frontend + Gradle + WebMvc + Security + GlobalExceptionHandler + .gitignore + SpaFallbackTest) |
| `4655087` | refactor | 4 | SPA 보안 모델 전환에 따라 테스트 probe 컨트롤러를 `/api/__probe`·`/api/probe/me`로 이동 |

## TDD 증적
**`SpaFallbackTest` 8 케이스 (RED → GREEN)**
- happy path 3: GET `/`, `/random-route`, `/board/123` → `forward("/index.html")`
- edge cases 4: `/api/auth/nonexistent` → 404 (폴백 안 됨), `/favicon.ico`·`/assets/main.js` → 정적 핸들러, POST `/random-route` → 폴백 안 됨, `/h2-console/` → 기존 동작
- 회귀 1: GET `/signup` → 기존 Thymeleaf 폼 (#5.4까지 유지)

**RED에서 선제 설계한 edge case**
- 입력 형식: 점 포함 정적 자원 vs 점 없는 SPA 라우트 분리
- 메서드: POST는 폴백 대상 외
- 보안 회귀: SPA 도입으로 비-API 경로가 공개되며 노출된 9개 테스트(/__probe/secured, /probe/me, /definitely-not-exist) → `/api/**` 아래로 마이그레이션 (commit `4655087`)

## Test plan
- [x] `./gradlew clean build` 로컬 초록불 — 100 tests PASS, INSTRUCTION 98.66%
- [x] `./gradlew jacocoTestCoverageVerification` 로컬 통과
- [ ] CI 초록불 (`Lint`, `Test + Coverage`, `Build (no tests)` 잡)
- [x] 수용 기준 검증 — `verifyFrontendBundle` 태스크가 `build/resources/main/static/index.html` 존재를 `check` 단계에서 강제

## 파일 변경 요약 (이슈 #30 본질 13개)

| # | 파일 | 구분 | 비고 |
|---|---|---|---|
| 1 | `frontend/package.json` | 신규 | Vite + React 18 + TS deps |
| 2 | `frontend/package-lock.json` | 신규 | npm install 결정성 |
| 3 | `frontend/vite.config.ts` | 신규 | `outDir = "dist"`, base `/` |
| 4 | `frontend/tsconfig.json` | 신규 | TS 표준 |
| 5 | `frontend/index.html` | 신규 | `<div id="root">` |
| 6 | `frontend/src/main.tsx` | 신규 | `createRoot(...).render(<App/>)` |
| 7 | `frontend/src/App.tsx` | 신규 | placeholder `"React OK"` |
| 8 | `build.gradle.kts` | 수정 | node-gradle 7.1.0, `buildFrontend`, `processResources` 통합, `verifyFrontendBundle` |
| 9 | `src/main/java/com/example/board/config/WebMvcConfig.java` | 신규 | SPA 폴백 ViewController + addResourceHandlers |
| 10 | `src/main/java/com/example/board/config/SecurityConfig.java` | 수정 | SPA 경로 GET permitAll |
| 11 | `src/main/java/com/example/board/common/GlobalExceptionHandler.java` | 수정 | Spring Boot 3.2+ `NoResourceFoundException` → 404 매핑 (방어) |
| 12 | `src/test/java/com/example/board/config/SpaFallbackTest.java` | 신규 | RED 테스트 8 케이스 |
| 13 | `.gitignore` | 수정 | `frontend/node_modules`, `frontend/dist`, `temp/` |

## 주의 — 파일 ≤10 규칙 예외

CLAUDE.md "이슈당 ≤10 파일" 제약 대비 본 PR의 #30 본질은 13개 (계획 +2). 사전 합의된 인프라 부트스트래핑 PR 예외:
- 계획에 포함 (11): 사용자 사전 승인 (foundation 예외)
- `GlobalExceptionHandler.java` 추가 (+1): Spring Boot 3.2+ `NoResourceFoundException`을 404로 매핑하지 않으면 SPA 도입 후 unmapped /api 경로가 500을 낼 수 있어 방어적 추가
- `frontend/package-lock.json` 추가 (+1): npm install 결정성 (best practice)

추가로 `chore` 커밋에 spotless 사전 드리프트 정리 36 파일 + suppressions.xml = 37 파일이 동봉됨. 이는 SessionEnd 훅이 자동 적용해야 했지만 누적된 코스메틱 정리. PR 본문 cleaner 위해 별도 chore 커밋으로 분리.

`refactor` 커밋의 4 파일은 SPA 보안 모델 전환의 직접 결과 (테스트 probe 경로 `/api/**` 아래로 이동) — 본질적으로 #30 도입 없이는 발생하지 않는 변경.

## 범위 밖 (후속 이슈)
- React Router 설치/사용 (#31)
- 로그인/회원가입 React 포팅 (#31, #32)
- Thymeleaf 의존성·템플릿 제거 (#33)
- Vitest 테스트 인프라 (필요 시 #31)

🤖 Generated with [Claude Code](https://claude.com/claude-code)
