### PR TITLE
feat: #45 게시판 React UI — 목록/상세/작성/수정/삭제

### DIFF
--- a/frontend/src/App.tsx
+++ b/frontend/src/App.tsx
@@ -1,18 +1,22 @@
-import { BrowserRouter, Route, Routes } from 'react-router-dom';
+import { BrowserRouter, Navigate, Route, Routes } from 'react-router-dom';
 import LoginPage from './pages/LoginPage';
 import SignupPage from './pages/SignupPage';
-
-function HomePlaceholder() {
-  return <h1>React OK</h1>;
-}
+import PostListPage from './pages/PostListPage';
+import PostDetailPage from './pages/PostDetailPage';
+import PostNewPage from './pages/PostNewPage';
+import PostEditPage from './pages/PostEditPage';
 
 export default function App() {
   return (
     <BrowserRouter>
       <Routes>
+        <Route path="/" element={<PostListPage />} />
+        <Route path="/posts/new" element={<PostNewPage />} />
+        <Route path="/posts/:id" element={<PostDetailPage />} />
+        <Route path="/posts/:id/edit" element={<PostEditPage />} />
         <Route path="/login" element={<LoginPage />} />
         <Route path="/signup" element={<SignupPage />} />
-        <Route path="*" element={<HomePlaceholder />} />
+        <Route path="*" element={<Navigate to="/" replace />} />
       </Routes>
     </BrowserRouter>
   );

--- a/frontend/src/api/posts.ts
+++ b/frontend/src/api/posts.ts
@@ -1,0 +1,98 @@
+import * as tokenStore from '../auth/tokenStore';
+import type { ApiErrorResponse } from './auth';
+
+export interface PostResponse {
+  id: number;
+  title: string;
+  content: string;
+  authorUsername: string;
+  createdAt: string;
+  updatedAt: string;
+}
+
+export interface PostPageResponse {
+  content: PostResponse[];
+  page: number;
+  size: number;
+  totalElements: number;
+  totalPages: number;
+}
+
+export interface PostWriteRequest {
+  title: string;
+  content: string;
+}
+
+export class PostError extends Error {
+  readonly status: number;
+  readonly response: ApiErrorResponse | null;
+  constructor(status: number, message: string, response: ApiErrorResponse | null) {
+    super(message);
+    this.name = 'PostError';
+    this.status = status;
+    this.response = response;
+  }
+}
+
+function authHeaders(): Record<string, string> {
+  const token = tokenStore.get();
+  return token ? { Authorization: `Bearer ${token}` } : {};
+}
+
+async function readError(res: Response): Promise<PostError> {
+  let body: ApiErrorResponse | null = null;
+  try {
+    body = (await res.json()) as ApiErrorResponse;
+  } catch {
+    body = null;
+  }
+  const message = body?.message || `요청을 처리하지 못했습니다 (HTTP ${res.status})`;
+  return new PostError(res.status, message, body);
+}
+
+export async function listPosts(page: number = 0, size: number = 10): Promise<PostPageResponse> {
+  const res = await fetch(`/api/posts?page=${page}&size=${size}`, {
+    method: 'GET',
+    headers: { Accept: 'application/json' },
+  });
+  if (res.ok) return (await res.json()) as PostPageResponse;
+  throw await readError(res);
+}
+
+export async function getPost(id: number): Promise<PostResponse> {
+  const res = await fetch(`/api/posts/${id}`, {
+    method: 'GET',
+    headers: { Accept: 'application/json' },
+  });
+  if (res.ok) return (await res.json()) as PostResponse;
+  throw await readError(res);
+}
+
+export async function createPost(request: PostWriteRequest): Promise<PostResponse> {
+  const res = await fetch('/api/posts', {
+    method: 'POST',
+    headers: { 'Content-Type': 'application/json', Accept: 'application/json', ...authHeaders() },
+    body: JSON.stringify(request),
+  });
+  if (res.status === 201) return (await res.json()) as PostResponse;
+  throw await readError(res);
+}
+
+export async function updatePost(id: number, request: PostWriteRequest): Promise<PostResponse> {
+  const res = await fetch(`/api/posts/${id}`, {
+    method: 'PUT',
+    headers: { 'Content-Type': 'application/json', Accept: 'application/json', ...authHeaders() },
+    body: JSON.stringify(request),
+  });
+  if (res.ok) return (await res.json()) as PostResponse;
+  throw await readError(res);
+}
+
+export async function deletePost(id: number): Promise<void> {
+  const res = await fetch(`/api/posts/${id}`, {
+    method: 'DELETE',
+    headers: { Accept: 'application/json', ...authHeaders() },
+  });
+  if (res.status === 204) return;
+  throw await readError(res);
+}

--- a/frontend/src/components/posts/PostDetail.tsx
+++ b/frontend/src/components/posts/PostDetail.tsx
@@ -1,0 +1,50 @@
+import { Link } from 'react-router-dom';
+import type { PostResponse } from '../../api/posts';
+import { postEditorialCss } from './postStyles';
+
+export interface PostDetailProps {
+  post: PostResponse;
+  canEdit: boolean;
+  deleteError?: string | null;
+  deleting?: boolean;
+  onDelete: () => void;
+}
+
+function formatDateTime(iso: string): string {
+  return iso.replace('T', ' ').slice(0, 16);
+}
+
+export function PostDetail(props: PostDetailProps) {
+  const { post, canEdit, deleteError, deleting, onDelete } = props;
+  return (
+    <div className="post-page">
+      <style>{postEditorialCss}</style>
+      <div className="post-shell">
+        <p className="post-eyebrow">Board · Post</p>
+        <h1 className="post-h1">{post.title}</h1>
+        <p className="post-detail-meta">
+          {post.authorUsername} · {formatDateTime(post.createdAt)}
+          {post.updatedAt !== post.createdAt && ` · 수정됨 ${formatDateTime(post.updatedAt)}`}
+        </p>
+        {deleteError && <div className="post-alert" role="alert">{deleteError}</div>}
+        <div className="post-toolbar">
+          <Link to="/" className="post-btn is-ghost">← 목록</Link>
+          {canEdit && (
+            <div className="post-toolbar-right">
+              <Link to={`/posts/${post.id}/edit`} className="post-btn is-ghost">수정</Link>
+              <button
+                type="button"
+                className="post-btn is-danger"
+                onClick={onDelete}
+                disabled={deleting}
+              >
+                {deleting ? '삭제 중…' : '삭제'}
+              </button>
+            </div>
+          )}
+        </div>
+        <div className="post-detail-body">{post.content}</div>
+      </div>
+    </div>
+  );
+}

--- a/frontend/src/components/posts/PostForm.stories.tsx
+++ b/frontend/src/components/posts/PostForm.stories.tsx
@@ -1,0 +1,86 @@
+import type { Meta, StoryObj } from '@storybook/react';
+import { useState } from 'react';
+import { PostForm, PostFormProps } from './PostForm';
+
+interface HostProps extends Omit<PostFormProps, 'title' | 'content' | 'onChange' | 'onSubmit'> {
+  initialTitle?: string;
+  initialContent?: string;
+}
+
+function Host({ initialTitle = '', initialContent = '', ...rest }: HostProps) {
+  const [title, setTitle] = useState(initialTitle);
+  const [content, setContent] = useState(initialContent);
+  const onChange: PostFormProps['onChange'] = (field, value) => {
+    if (field === 'title') setTitle(value);
+    else setContent(value);
+  };
+  return (
+    <PostForm
+      title={title}
+      content={content}
+      onChange={onChange}
+      onSubmit={() => {
+        /* no-op in Storybook */
+      }}
+      {...rest}
+    />
+  );
+}
+
+const meta: Meta<typeof Host> = {
+  title: 'Posts/PostForm',
+  component: Host,
+  parameters: { layout: 'fullscreen' },
+};
+export default meta;
+
+type Story = StoryObj<typeof Host>;
+
+export const CreateIdle: Story = { args: { mode: 'create' } };
+
+export const CreateSubmitting: Story = {
+  args: {
+    mode: 'create',
+    initialTitle: '오늘의 회고',
+    initialContent: '하루를 돌아본다.\n\n잘한 일과 아쉬운 점을 정리하자.',
+    submitting: true,
+  },
+};
+
+export const CreateFieldError: Story = {
+  args: {
+    mode: 'create',
+    initialTitle: '',
+    initialContent: '',
+    fieldErrors: {
+      title: 'title은 필수입니다',
+      content: 'content는 필수입니다',
+    },
+  },
+};
+
+export const CreateServerError: Story = {
+  args: {
+    mode: 'create',
+    initialTitle: '제목',
+    initialContent: '본문',
+    error: 'title: title은 최대 100자입니다',
+  },
+};
+
+export const UpdateIdle: Story = {
+  args: {
+    mode: 'update',
+    initialTitle: '원래 제목',
+    initialContent: '원래 본문 내용입니다.\n\n수정해보세요.',
+  },
+};
+
+export const UpdateForbidden: Story = {
+  args: {
+    mode: 'update',
+    initialTitle: '남의 글',
+    initialContent: '본문',
+    error: '본인의 글만 수정/삭제할 수 있습니다',
+  },
+};

--- a/frontend/src/components/posts/PostForm.tsx
+++ b/frontend/src/components/posts/PostForm.tsx
@@ -1,0 +1,88 @@
+import { FormEvent } from 'react';
+import { authEditorialCss } from '../auth/authStyles';
+import { postEditorialCss } from './postStyles';
+
+export type PostFormField = 'title' | 'content';
+export type PostFormMode = 'create' | 'update';
+
+export interface PostFormProps {
+  mode: PostFormMode;
+  title: string;
+  content: string;
+  onChange: (field: PostFormField, value: string) => void;
+  onSubmit: () => void;
+  submitting?: boolean;
+  error?: string | null;
+  fieldErrors?: Partial<Record<PostFormField, string>>;
+}
+
+const COPY: Record<PostFormMode, { eyebrow: string; heading: string; sub: string; cta: string; ctaPending: string }> = {
+  create: {
+    eyebrow: 'Board · New',
+    heading: '글쓰기',
+    sub: '제목과 내용을 입력해 게시판에 글을 남겨보세요.',
+    cta: '등록',
+    ctaPending: '등록 중…',
+  },
+  update: {
+    eyebrow: 'Board · Edit',
+    heading: '글 수정',
+    sub: '내용을 다듬고 다시 저장하세요.',
+    cta: '수정',
+    ctaPending: '수정 중…',
+  },
+};
+
+export function PostForm(props: PostFormProps) {
+  const { mode, title, content, onChange, onSubmit, submitting, error, fieldErrors } = props;
+  const copy = COPY[mode];
+  const titleErr = fieldErrors?.title;
+  const contentErr = fieldErrors?.content;
+  const handleSubmit = (event: FormEvent<HTMLFormElement>) => {
+    event.preventDefault();
+    if (!submitting) onSubmit();
+  };
+  return (
+    <div className="auth-edit-page">
+      <style>{authEditorialCss}</style>
+      <style>{postEditorialCss}</style>
+      <div className="auth-edit-card post-form-card">
+        <p className="auth-edit-eyebrow">{copy.eyebrow}</p>
+        <h1 className="auth-edit-h1">{copy.heading}</h1>
+        <p className="auth-edit-sub">{copy.sub}</p>
+        {error && <div className="auth-edit-alert" role="alert">{error}</div>}
+        <form onSubmit={handleSubmit} noValidate>
+          <div className="auth-edit-field">
+            <label className="auth-edit-label" htmlFor="title">title</label>
+            <div className="auth-edit-inputwrap">
+              <input
+                id="title"
+                name="title"
+                type="text"
+                className={`auth-edit-input${titleErr ? ' is-error' : ''}`}
+                value={title}
+                onChange={(e) => onChange('title', e.target.value)}
+                maxLength={120}
+              />
+            </div>
+            {titleErr && <div className="auth-edit-fielderr">{titleErr}</div>}
+          </div>
+          <div className="auth-edit-field">
+            <label className="auth-edit-label" htmlFor="content">content</label>
+            <textarea
+              id="content"
+              name="content"
+              className={`post-textarea${contentErr ? ' is-error' : ''}`}
+              value={content}
+              onChange={(e) => onChange('content', e.target.value)}
+            />
+            {contentErr && <div className="auth-edit-fielderr">{contentErr}</div>}
+          </div>
+          <button type="submit" className="auth-edit-cta" disabled={submitting}>
+            {submitting ? copy.ctaPending : copy.cta}
+          </button>
+        </form>
+      </div>
+    </div>
+  );
+}

--- a/frontend/src/components/posts/PostList.tsx
+++ b/frontend/src/components/posts/PostList.tsx
@@ -1,0 +1,86 @@
+import { Link } from 'react-router-dom';
+import type { PostResponse } from '../../api/posts';
+import { postEditorialCss } from './postStyles';
+
+export interface PostListProps {
+  posts: PostResponse[];
+  loading?: boolean;
+  error?: string | null;
+  page: number;
+  totalPages: number;
+  onPrev: () => void;
+  onNext: () => void;
+  onRetry?: () => void;
+}
+
+function formatDate(iso: string): string {
+  return iso.slice(0, 10);
+}
+
+export function PostList(props: PostListProps) {
+  const { posts, loading, error, page, totalPages, onPrev, onNext, onRetry } = props;
+  const hasPrev = page > 0;
+  const hasNext = page < Math.max(totalPages - 1, 0);
+  return (
+    <div className="post-page">
+      <style>{postEditorialCss}</style>
+      <div className="post-shell">
+        <p className="post-eyebrow">Board · Posts</p>
+        <h1 className="post-h1">게시판</h1>
+        <div className="post-toolbar">
+          <div className="post-pagination-info">
+            {totalPages > 0 ? `${page + 1} / ${totalPages}` : ' '}
+          </div>
+          <div className="post-toolbar-right">
+            <Link to="/posts/new" className="post-btn">글쓰기</Link>
+          </div>
+        </div>
+        {error && (
+          <div className="post-alert" role="alert">
+            <span>{error}</span>
+            {onRetry && (
+              <>
+                {' '}
+                <button type="button" className="post-btn is-ghost" onClick={onRetry}>재시도</button>
+              </>
+            )}
+          </div>
+        )}
+        {loading && !error && <div className="post-empty">불러오는 중…</div>}
+        {!loading && !error && posts.length === 0 && (
+          <div className="post-empty">아직 글이 없습니다. 첫 글을 작성해보세요.</div>
+        )}
+        {!error && posts.length > 0 && (
+          <ul className="post-list">
+            {posts.map((p) => (
+              <li key={p.id} className="post-list-item">
+                <Link to={`/posts/${p.id}`} className="post-list-link">
+                  <p className="post-list-title">{p.title}</p>
+                  <p className="post-list-meta">{p.authorUsername} · {formatDate(p.createdAt)}</p>
+                </Link>
+              </li>
+            ))}
+          </ul>
+        )}
+        <div className="post-pagination">
+          <button
+            type="button"
+            className="post-btn is-ghost"
+            disabled={!hasPrev || loading}
+            onClick={onPrev}
+          >
+            이전
+          </button>
+          <button
+            type="button"
+            className="post-btn is-ghost"
+            disabled={!hasNext || loading}
+            onClick={onNext}
+          >
+            다음
+          </button>
+        </div>
+      </div>
+    </div>
+  );
+}

--- a/frontend/src/components/posts/postStyles.ts
+++ b/frontend/src/components/posts/postStyles.ts
@@ -1,0 +1,32 @@
+export const postEditorialCss = `
+.post-page { min-height: 100vh; background: #f6f4ef; padding: 56px 16px 96px; font-family: 'Inter', system-ui, sans-serif; color: #1a1a1a; }
+.post-shell { max-width: 720px; margin: 0 auto; }
+.post-eyebrow { font-size: 12px; letter-spacing: 0.18em; text-transform: uppercase; color: #8a7f6f; margin: 0 0 8px; }
+.post-h1 { font-family: 'Source Serif Pro', Georgia, 'Times New Roman', serif; font-size: 34px; line-height: 1.15; margin: 0 0 28px; font-weight: 600; }
+.post-toolbar { display: flex; justify-content: space-between; align-items: center; margin-bottom: 24px; gap: 12px; }
+.post-toolbar-right { display: flex; gap: 10px; align-items: center; }
+.post-btn { display: inline-block; padding: 10px 18px; background: #1a1a1a; color: #fff; border: 0; border-radius: 8px; font-size: 14px; font-weight: 600; letter-spacing: 0.02em; cursor: pointer; text-decoration: none; transition: background 120ms; }
+.post-btn:hover:not(:disabled) { background: #000; }
+.post-btn:disabled { background: #6e6358; cursor: not-allowed; }
+.post-btn.is-ghost { background: #fff; color: #1a1a1a; border: 1px solid #ddd5c5; }
+.post-btn.is-ghost:hover:not(:disabled) { background: #fafaf6; }
+.post-btn.is-danger { background: #b6324a; }
+.post-btn.is-danger:hover:not(:disabled) { background: #8c2237; }
+.post-list { list-style: none; padding: 0; margin: 0; border-top: 1px solid #ece8df; }
+.post-list-item { border-bottom: 1px solid #ece8df; padding: 18px 4px; }
+.post-list-link { display: block; color: #1a1a1a; text-decoration: none; }
+.post-list-link:hover .post-list-title { text-decoration: underline; }
+.post-list-title { font-family: 'Source Serif Pro', Georgia, 'Times New Roman', serif; font-size: 20px; font-weight: 600; margin: 0 0 6px; }
+.post-list-meta { font-size: 12.5px; color: #8a7f6f; }
+.post-empty { padding: 64px 0; text-align: center; color: #8a7f6f; font-size: 15px; }
+.post-pagination { display: flex; justify-content: center; align-items: center; gap: 12px; margin-top: 28px; }
+.post-pagination .post-btn { padding: 8px 16px; }
+.post-pagination-info { font-size: 13px; color: #5b5247; }
+.post-detail-meta { color: #8a7f6f; font-size: 13.5px; margin: -16px 0 28px; border-bottom: 1px solid #ece8df; padding-bottom: 18px; }
+.post-detail-body { font-family: 'Source Serif Pro', Georgia, 'Times New Roman', serif; font-size: 18px; line-height: 1.7; white-space: pre-wrap; word-break: break-word; }
+.post-alert { background: #fdf3f4; border: 1px solid #f1ccd2; color: #8c2237; padding: 12px 14px; border-radius: 8px; font-size: 14px; margin-bottom: 18px; }
+.post-form-card { width: 100%; background: #fff; border: 1px solid #ece8df; border-radius: 14px; padding: 32px 32px 28px; box-shadow: 0 4px 24px rgba(20,20,30,0.05); }
+.post-textarea { width: 100%; box-sizing: border-box; padding: 12px 14px; border: 1px solid #ddd5c5; border-radius: 8px; font-size: 15px; background: #fafaf6; font-family: inherit; resize: vertical; min-height: 220px; line-height: 1.6; transition: border-color 120ms, box-shadow 120ms; outline: none; }
+.post-textarea:focus { border-color: #1a1a1a; box-shadow: 0 0 0 3px rgba(26,26,26,0.08); background: #fff; }
+.post-textarea.is-error { border-color: #b6324a; background: #fdf3f4; }
+`;

--- a/frontend/src/pages/PostDetailPage.test.tsx
+++ b/frontend/src/pages/PostDetailPage.test.tsx
@@ -1,0 +1,217 @@
+import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest';
+import { act, cleanup, fireEvent, render, screen } from '@testing-library/react';
+import { MemoryRouter, Route, Routes, useLocation } from 'react-router-dom';
+import PostDetailPage from './PostDetailPage';
+import * as tokenStore from '../auth/tokenStore';
+
+afterEach(() => {
+  cleanup();
+  vi.restoreAllMocks();
+  tokenStore.clear();
+});
+
+beforeEach(() => {
+  delete (globalThis as { fetch?: typeof fetch }).fetch;
+  tokenStore.clear();
+});
+
+interface MockResponse {
+  status: number;
+  body: unknown;
+}
+
+function mockFetchSequence(responses: MockResponse[]) {
+  let i = 0;
+  const fn = vi.fn(() => {
+    const r = responses[Math.min(i, responses.length - 1)];
+    i += 1;
+    return Promise.resolve({
+      ok: r.status >= 200 && r.status < 300,
+      status: r.status,
+      json: async () => r.body,
+    } as Response);
+  });
+  globalThis.fetch = fn as unknown as typeof fetch;
+  return fn;
+}
+
+let currentPath: string | null = null;
+function LocationSpy() {
+  const loc = useLocation();
+  currentPath = loc.pathname;
+  return null;
+}
+
+function renderDetailPage(id: number = 7) {
+  currentPath = null;
+  return render(
+    <MemoryRouter initialEntries={[`/posts/${id}`]}>
+      <Routes>
+        <Route path="/posts/:id" element={<PostDetailPage />} />
+        <Route path="/posts/:id/edit" element={<div data-testid="edit" />} />
+        <Route path="/" element={<div data-testid="home">HOME</div>} />
+        <Route path="/login" element={<div data-testid="login">LOGIN</div>} />
+      </Routes>
+      <LocationSpy />
+    </MemoryRouter>,
+  );
+}
+
+const post = (overrides: Partial<{ id: number; title: string; content: string; authorUsername: string }> = {}) => ({
+  id: 7,
+  title: '오늘의 글',
+  content: '내용\n두 번째 줄',
+  authorUsername: 'marco',
+  createdAt: '2026-04-28T00:00:00Z',
+  updatedAt: '2026-04-28T00:00:00Z',
+  ...overrides,
+});
+
+const errorBody = (status: number, message: string, path = '/api/posts/7') => ({
+  status,
+  error: 'Error',
+  message,
+  path,
+  timestamp: '2026-04-28T00:00:00Z',
+});
+
+async function flush() {
+  await act(async () => {
+    await Promise.resolve();
+    await Promise.resolve();
+  });
+}
+
+describe('PostDetailPage', () => {
+  it('마운트_시_GET_/api/posts/:id_로_본문을_가져온다', async () => {
+    const fn = mockFetchSequence([{ status: 200, body: post() }]);
+    await act(async () => {
+      renderDetailPage(7);
+    });
+    await flush();
+    const [url] = fn.mock.calls[0] as [string, RequestInit | undefined];
+    expect(url).toBe('/api/posts/7');
+    expect(screen.getByText('오늘의 글')).toBeTruthy();
+    expect(screen.getByText(/marco/)).toBeTruthy();
+  });
+
+  it('404_응답이면_없음_안내를_렌더한다', async () => {
+    mockFetchSequence([{ status: 404, body: errorBody(404, '게시글을 찾을 수 없습니다: 7') }]);
+    await act(async () => {
+      renderDetailPage(7);
+    });
+    await flush();
+    expect(screen.getByText(/게시글을 찾을 수 없습니다/)).toBeTruthy();
+  });
+
+  it('비로그인이면_수정_삭제_버튼이_안_보인다', async () => {
+    mockFetchSequence([{ status: 200, body: post() }]);
+    await act(async () => {
+      renderDetailPage(7);
+    });
+    await flush();
+    expect(screen.queryByRole('link', { name: /수정/ })).toBeNull();
+    expect(screen.queryByRole('button', { name: /삭제/ })).toBeNull();
+  });
+
+  it('로그인_상태면_수정_링크와_삭제_버튼이_보인다', async () => {
+    tokenStore.set('t.k.n');
+    mockFetchSequence([{ status: 200, body: post() }]);
+    await act(async () => {
+      renderDetailPage(7);
+    });
+    await flush();
+    expect(screen.getByRole('link', { name: /수정/ })).toBeTruthy();
+    expect(screen.getByRole('button', { name: /^삭제$/ })).toBeTruthy();
+  });
+
+  it('수정_링크는_/posts/:id/edit_로_라우팅한다', async () => {
+    tokenStore.set('t.k.n');
+    mockFetchSequence([{ status: 200, body: post() }]);
+    await act(async () => {
+      renderDetailPage(7);
+    });
+    await flush();
+    await act(async () => {
+      fireEvent.click(screen.getByRole('link', { name: /수정/ }));
+    });
+    expect(currentPath).toBe('/posts/7/edit');
+  });
+
+  it('삭제_버튼_클릭_시_confirm_확인_후_DELETE_요청하고_홈으로_이동한다', async () => {
+    tokenStore.set('t.k.n');
+    const fn = mockFetchSequence([
+      { status: 200, body: post() },
+      { status: 204, body: null },
+    ]);
+    const confirmSpy = vi.spyOn(window, 'confirm').mockReturnValue(true);
+    await act(async () => {
+      renderDetailPage(7);
+    });
+    await flush();
+    await act(async () => {
+      fireEvent.click(screen.getByRole('button', { name: /^삭제$/ }));
+    });
+    await flush();
+    expect(confirmSpy).toHaveBeenCalled();
+    expect(fn).toHaveBeenCalledTimes(2);
+    const [url, init] = fn.mock.calls[1] as [string, RequestInit];
+    expect(url).toBe('/api/posts/7');
+    expect(init.method).toBe('DELETE');
+    expect((init.headers as Record<string, string>).Authorization).toBe('Bearer t.k.n');
+    expect(currentPath).toBe('/');
+  });
+
+  it('삭제_confirm_취소_시_요청하지_않는다', async () => {
+    tokenStore.set('t.k.n');
+    const fn = mockFetchSequence([{ status: 200, body: post() }]);
+    vi.spyOn(window, 'confirm').mockReturnValue(false);
+    await act(async () => {
+      renderDetailPage(7);
+    });
+    await flush();
+    await act(async () => {
+      fireEvent.click(screen.getByRole('button', { name: /^삭제$/ }));
+    });
+    await flush();
+    expect(fn).toHaveBeenCalledTimes(1);
+    expect(currentPath).toBe('/posts/7');
+  });
+
+  it('삭제_시_403_이면_본인의_글만_메시지를_렌더한다', async () => {
+    tokenStore.set('t.k.n');
+    mockFetchSequence([
+      { status: 200, body: post() },
+      { status: 403, body: errorBody(403, '본인의 글만 수정/삭제할 수 있습니다') },
+    ]);
+    vi.spyOn(window, 'confirm').mockReturnValue(true);
+    await act(async () => {
+      renderDetailPage(7);
+    });
+    await flush();
+    await act(async () => {
+      fireEvent.click(screen.getByRole('button', { name: /^삭제$/ }));
+    });
+    await flush();
+    expect(screen.getByText(/본인의 글만/)).toBeTruthy();
+    expect(currentPath).toBe('/posts/7');
+  });
+
+  it('삭제_시_401_이면_/login_으로_redirect_한다', async () => {
+    tokenStore.set('expired');
+    mockFetchSequence([
+      { status: 200, body: post() },
+      { status: 401, body: errorBody(401, '인증이 필요합니다') },
+    ]);
+    vi.spyOn(window, 'confirm').mockReturnValue(true);
+    await act(async () => {
+      renderDetailPage(7);
+    });
+    await flush();
+    await act(async () => {
+      fireEvent.click(screen.getByRole('button', { name: /^삭제$/ }));
+    });
+    await flush();
+    expect(currentPath).toBe('/login');
+  });
+});

--- a/frontend/src/pages/PostDetailPage.tsx
+++ b/frontend/src/pages/PostDetailPage.tsx
@@ -1,0 +1,90 @@
+import { useEffect, useState } from 'react';
+import { useNavigate, useParams } from 'react-router-dom';
+import { deletePost, getPost, PostError, type PostResponse } from '../api/posts';
+import * as tokenStore from '../auth/tokenStore';
+import { PostDetail } from '../components/posts/PostDetail';
+
+const NOT_FOUND_MESSAGE = '게시글을 찾을 수 없습니다';
+const FORBIDDEN_MESSAGE = '본인의 글만 수정/삭제할 수 있습니다';
+const FALLBACK_ERROR = '요청을 처리하지 못했습니다';
+
+export default function PostDetailPage() {
+  const params = useParams<{ id: string }>();
+  const navigate = useNavigate();
+  const id = Number(params.id);
+  const [post, setPost] = useState<PostResponse | null>(null);
+  const [loadError, setLoadError] = useState<string | null>(null);
+  const [deleteError, setDeleteError] = useState<string | null>(null);
+  const [deleting, setDeleting] = useState(false);
+  const [authed] = useState<boolean>(() => tokenStore.get() !== null);
+
+  useEffect(() => {
+    let cancelled = false;
+    getPost(id)
+      .then((res) => {
+        if (!cancelled) setPost(res);
+      })
+      .catch((e) => {
+        if (cancelled) return;
+        if (e instanceof PostError && e.status === 404) setLoadError(NOT_FOUND_MESSAGE);
+        else if (e instanceof PostError) setLoadError(e.message || FALLBACK_ERROR);
+        else setLoadError(FALLBACK_ERROR);
+      });
+    return () => {
+      cancelled = true;
+    };
+  }, [id]);
+
+  const onDelete = () => {
+    if (!window.confirm('이 글을 삭제하시겠습니까?')) return;
+    setDeleting(true);
+    setDeleteError(null);
+    deletePost(id)
+      .then(() => navigate('/'))
+      .catch((e) => {
+        if (e instanceof PostError && e.status === 401) {
+          tokenStore.clear();
+          navigate('/login');
+          return;
+        }
+        if (e instanceof PostError && e.status === 403) {
+          setDeleteError(FORBIDDEN_MESSAGE);
+        } else if (e instanceof PostError) {
+          setDeleteError(e.message || FALLBACK_ERROR);
+        } else {
+          setDeleteError(FALLBACK_ERROR);
+        }
+      })
+      .finally(() => setDeleting(false));
+  };
+
+  if (loadError) {
+    return (
+      <div className="post-page">
+        <div className="post-shell">
+          <div className="post-alert" role="alert">{loadError}</div>
+        </div>
+      </div>
+    );
+  }
+
+  if (!post) {
+    return (
+      <div className="post-page">
+        <div className="post-shell">
+          <div className="post-empty">불러오는 중…</div>
+        </div>
+      </div>
+    );
+  }
+
+  return (
+    <PostDetail
+      post={post}
+      canEdit={authed}
+      deleteError={deleteError}
+      deleting={deleting}
+      onDelete={onDelete}
+    />
+  );
+}

--- a/frontend/src/pages/PostEditPage.test.tsx
+++ b/frontend/src/pages/PostEditPage.test.tsx
@@ -1,0 +1,184 @@
+import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest';
+import { act, cleanup, fireEvent, render, screen } from '@testing-library/react';
+import { MemoryRouter, Route, Routes, useLocation } from 'react-router-dom';
+import PostEditPage from './PostEditPage';
+import * as tokenStore from '../auth/tokenStore';
+
+afterEach(() => {
+  cleanup();
+  vi.restoreAllMocks();
+  tokenStore.clear();
+});
+
+beforeEach(() => {
+  delete (globalThis as { fetch?: typeof fetch }).fetch;
+  tokenStore.clear();
+});
+
+interface MockResponse {
+  status: number;
+  body: unknown;
+}
+
+function mockFetchSequence(responses: MockResponse[]) {
+  let i = 0;
+  const fn = vi.fn(() => {
+    const r = responses[Math.min(i, responses.length - 1)];
+    i += 1;
+    return Promise.resolve({
+      ok: r.status >= 200 && r.status < 300,
+      status: r.status,
+      json: async () => r.body,
+    } as Response);
+  });
+  globalThis.fetch = fn as unknown as typeof fetch;
+  return fn;
+}
+
+let currentPath: string | null = null;
+function LocationSpy() {
+  const loc = useLocation();
+  currentPath = loc.pathname;
+  return null;
+}
+
+function renderEditPage(id: number = 7) {
+  currentPath = null;
+  return render(
+    <MemoryRouter initialEntries={[`/posts/${id}/edit`]}>
+      <Routes>
+        <Route path="/posts/:id/edit" element={<PostEditPage />} />
+        <Route path="/posts/:id" element={<div data-testid="detail" />} />
+        <Route path="/login" element={<div data-testid="login">LOGIN</div>} />
+      </Routes>
+      <LocationSpy />
+    </MemoryRouter>,
+  );
+}
+
+const post = (overrides: Partial<{ title: string; content: string }> = {}) => ({
+  id: 7,
+  title: '원래 제목',
+  content: '원래 본문',
+  authorUsername: 'marco',
+  createdAt: '2026-04-28T00:00:00Z',
+  updatedAt: '2026-04-28T00:00:00Z',
+  ...overrides,
+});
+
+const errorBody = (status: number, message: string) => ({
+  status,
+  error: 'Error',
+  message,
+  path: '/api/posts/7',
+  timestamp: '2026-04-28T00:00:00Z',
+});
+
+async function flush() {
+  await act(async () => {
+    await Promise.resolve();
+    await Promise.resolve();
+  });
+}
+
+async function clickSubmit(name: RegExp = /^수정$/) {
+  await act(async () => {
+    fireEvent.click(screen.getByRole('button', { name }));
+  });
+}
+
+describe('PostEditPage', () => {
+  it('비로그인_상태에서_접근_시_/login_으로_redirect_한다', () => {
+    renderEditPage(7);
+    expect(currentPath).toBe('/login');
+  });
+
+  it('마운트_시_GET_/api/posts/:id_로_입력값을_prefill_한다', async () => {
+    tokenStore.set('t.k.n');
+    mockFetchSequence([{ status: 200, body: post() }]);
+    await act(async () => {
+      renderEditPage(7);
+    });
+    await flush();
+    const titleInput = screen.getByLabelText(/^title$/i) as HTMLInputElement;
+    const contentInput = screen.getByLabelText(/^content$/i) as HTMLTextAreaElement;
+    expect(titleInput.value).toBe('원래 제목');
+    expect(contentInput.value).toBe('원래 본문');
+  });
+
+  it('prefill_404이면_에러_배너를_렌더한다', async () => {
+    tokenStore.set('t.k.n');
+    mockFetchSequence([{ status: 404, body: errorBody(404, '게시글을 찾을 수 없습니다: 7') }]);
+    await act(async () => {
+      renderEditPage(7);
+    });
+    await flush();
+    expect(screen.getByText(/게시글을 찾을 수 없습니다/)).toBeTruthy();
+  });
+
+  it('정상_제출이면_PUT_/api/posts/:id_을_Bearer_헤더와_함께_호출한다', async () => {
+    tokenStore.set('t.k.n');
+    const fn = mockFetchSequence([
+      { status: 200, body: post() },
+      { status: 200, body: post({ title: '바뀐 제목', content: '바뀐 본문' }) },
+    ]);
+    await act(async () => {
+      renderEditPage(7);
+    });
+    await flush();
+    fireEvent.change(screen.getByLabelText(/^title$/i), { target: { value: '바뀐 제목' } });
+    fireEvent.change(screen.getByLabelText(/^content$/i), { target: { value: '바뀐 본문' } });
+    await clickSubmit();
+    await flush();
+    const [url, init] = fn.mock.calls[1] as [string, RequestInit];
+    expect(url).toBe('/api/posts/7');
+    expect(init.method).toBe('PUT');
+    expect((init.headers as Record<string, string>).Authorization).toBe('Bearer t.k.n');
+    expect(JSON.parse(init.body as string)).toEqual({ title: '바뀐 제목', content: '바뀐 본문' });
+    expect(currentPath).toBe('/posts/7');
+  });
+
+  it('title을_빈_값으로_제출하면_검증_메시지가_뜨고_PUT은_호출되지_않는다', async () => {
+    tokenStore.set('t.k.n');
+    const fn = mockFetchSequence([{ status: 200, body: post() }]);
+    await act(async () => {
+      renderEditPage(7);
+    });
+    await flush();
+    fireEvent.change(screen.getByLabelText(/^title$/i), { target: { value: '' } });
+    await clickSubmit();
+    expect(fn).toHaveBeenCalledTimes(1);
+    expect(screen.getByText(/title은 필수입니다/)).toBeTruthy();
+  });
+
+  it('403_응답_시_본인의_글만_메시지를_렌더한다', async () => {
+    tokenStore.set('t.k.n');
+    mockFetchSequence([
+      { status: 200, body: post() },
+      { status: 403, body: errorBody(403, '본인의 글만 수정/삭제할 수 있습니다') },
+    ]);
+    await act(async () => {
+      renderEditPage(7);
+    });
+    await flush();
+    await clickSubmit();
+    await flush();
+    expect(screen.getByText(/본인의 글만/)).toBeTruthy();
+    expect(currentPath).toBe('/posts/7/edit');
+  });
+
+  it('401_응답_시_/login_으로_redirect_한다', async () => {
+    tokenStore.set('expired');
+    mockFetchSequence([
+      { status: 200, body: post() },
+      { status: 401, body: errorBody(401, '인증이 필요합니다') },
+    ]);
+    await act(async () => {
+      renderEditPage(7);
+    });
+    await flush();
+    await clickSubmit();
+    await flush();
+    expect(currentPath).toBe('/login');
+  });
+});

--- a/frontend/src/pages/PostEditPage.tsx
+++ b/frontend/src/pages/PostEditPage.tsx
@@ -1,0 +1,119 @@
+import { useEffect, useState } from 'react';
+import { Navigate, useNavigate, useParams } from 'react-router-dom';
+import { getPost, PostError, updatePost } from '../api/posts';
+import * as tokenStore from '../auth/tokenStore';
+import { PostForm, type PostFormField } from '../components/posts/PostForm';
+
+const NOT_FOUND_MESSAGE = '게시글을 찾을 수 없습니다';
+const FORBIDDEN_MESSAGE = '본인의 글만 수정/삭제할 수 있습니다';
+const FALLBACK_ERROR = '요청을 처리하지 못했습니다';
+
+function validate(title: string, content: string): Partial<Record<PostFormField, string>> {
+  const errors: Partial<Record<PostFormField, string>> = {};
+  if (title.trim().length === 0) errors.title = 'title은 필수입니다';
+  else if (title.length > 100) errors.title = 'title은 최대 100자입니다';
+  if (content.length === 0) errors.content = 'content는 필수입니다';
+  return errors;
+}
+
+export default function PostEditPage() {
+  const params = useParams<{ id: string }>();
+  const navigate = useNavigate();
+  const id = Number(params.id);
+  const isAuthed = tokenStore.get() !== null;
+  const [title, setTitle] = useState('');
+  const [content, setContent] = useState('');
+  const [loadError, setLoadError] = useState<string | null>(null);
+  const [submitting, setSubmitting] = useState(false);
+  const [error, setError] = useState<string | null>(null);
+  const [fieldErrors, setFieldErrors] = useState<Partial<Record<PostFormField, string>>>({});
+
+  useEffect(() => {
+    if (!isAuthed) return undefined;
+    let cancelled = false;
+    getPost(id)
+      .then((res) => {
+        if (cancelled) return;
+        setTitle(res.title);
+        setContent(res.content);
+      })
+      .catch((e) => {
+        if (cancelled) return;
+        if (e instanceof PostError && e.status === 404) setLoadError(NOT_FOUND_MESSAGE);
+        else if (e instanceof PostError) setLoadError(e.message || FALLBACK_ERROR);
+        else setLoadError(FALLBACK_ERROR);
+      });
+    return () => {
+      cancelled = true;
+    };
+  }, [id, isAuthed]);
+
+  if (!isAuthed) {
+    return <Navigate to="/login" replace />;
+  }
+
+  const onChange = (field: PostFormField, value: string) => {
+    if (field === 'title') setTitle(value);
+    else setContent(value);
+    setFieldErrors((prev) => {
+      if (!prev[field]) return prev;
+      const next = { ...prev };
+      delete next[field];
+      return next;
+    });
+    if (error) setError(null);
+  };
+
+  const onSubmit = async () => {
+    const errors = validate(title, content);
+    if (Object.keys(errors).length > 0) {
+      setFieldErrors(errors);
+      return;
+    }
+    setFieldErrors({});
+    setError(null);
+    setSubmitting(true);
+    try {
+      await updatePost(id, { title: title.trim(), content });
+      navigate(`/posts/${id}`);
+    } catch (e) {
+      if (e instanceof PostError && e.status === 401) {
+        tokenStore.clear();
+        navigate('/login');
+        return;
+      }
+      if (e instanceof PostError && e.status === 403) {
+        setError(FORBIDDEN_MESSAGE);
+      } else if (e instanceof PostError) {
+        setError(e.message || FALLBACK_ERROR);
+      } else {
+        setError(FALLBACK_ERROR);
+      }
+    } finally {
+      setSubmitting(false);
+    }
+  };
+
+  if (loadError) {
+    return (
+      <div className="post-page">
+        <div className="post-shell">
+          <div className="post-alert" role="alert">{loadError}</div>
+        </div>
+      </div>
+    );
+  }
+
+  return (
+    <PostForm
+      mode="update"
+      title={title}
+      content={content}
+      onChange={onChange}
+      onSubmit={onSubmit}
+      submitting={submitting}
+      error={error}
+      fieldErrors={fieldErrors}
+    />
+  );
+}

--- a/frontend/src/pages/PostListPage.test.tsx
+++ b/frontend/src/pages/PostListPage.test.tsx
@@ -1,0 +1,195 @@
+import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest';
+import { act, cleanup, fireEvent, render, screen } from '@testing-library/react';
+import { MemoryRouter, Route, Routes, useLocation } from 'react-router-dom';
+import PostListPage from './PostListPage';
+
+afterEach(() => {
+  cleanup();
+  vi.restoreAllMocks();
+});
+
+beforeEach(() => {
+  delete (globalThis as { fetch?: typeof fetch }).fetch;
+});
+
+interface MockResponse {
+  status: number;
+  body: unknown;
+}
+
+function mockFetchSequence(responses: MockResponse[]) {
+  let i = 0;
+  const fn = vi.fn(() => {
+    const r = responses[Math.min(i, responses.length - 1)];
+    i += 1;
+    return Promise.resolve({
+      ok: r.status >= 200 && r.status < 300,
+      status: r.status,
+      json: async () => r.body,
+    } as Response);
+  });
+  globalThis.fetch = fn as unknown as typeof fetch;
+  return fn;
+}
+
+let currentPath: string | null = null;
+function LocationSpy() {
+  const loc = useLocation();
+  currentPath = loc.pathname;
+  return null;
+}
+
+function renderListPage() {
+  currentPath = null;
+  return render(
+    <MemoryRouter initialEntries={['/']}>
+      <Routes>
+        <Route path="/" element={<PostListPage />} />
+        <Route path="/posts/:id" element={<div data-testid="detail" />} />
+        <Route path="/posts/new" element={<div data-testid="new" />} />
+      </Routes>
+      <LocationSpy />
+    </MemoryRouter>,
+  );
+}
+
+const listBody = (overrides: Partial<{ content: unknown[]; page: number; size: number; totalElements: number; totalPages: number }> = {}) => ({
+  content: [],
+  page: 0,
+  size: 10,
+  totalElements: 0,
+  totalPages: 0,
+  ...overrides,
+});
+
+const samplePost = (id: number, overrides: Partial<{ title: string; authorUsername: string; createdAt: string }> = {}) => ({
+  id,
+  title: `글 ${id}`,
+  content: `본문 ${id}`,
+  authorUsername: 'marco',
+  createdAt: '2026-04-28T00:00:00Z',
+  updatedAt: '2026-04-28T00:00:00Z',
+  ...overrides,
+});
+
+async function flush() {
+  await act(async () => {
+    await Promise.resolve();
+    await Promise.resolve();
+  });
+}
+
+describe('PostListPage', () => {
+  it('마운트_시_GET_/api/posts_를_page0_size10_으로_호출한다', async () => {
+    const fn = mockFetchSequence([
+      { status: 200, body: listBody({ content: [samplePost(1)], totalElements: 1, totalPages: 1 }) },
+    ]);
+    await act(async () => {
+      renderListPage();
+    });
+    await flush();
+    expect(fn).toHaveBeenCalledTimes(1);
+    const [url, init] = fn.mock.calls[0] as [string, RequestInit | undefined];
+    expect(url).toBe('/api/posts?page=0&size=10');
+    expect(init?.method ?? 'GET').toBe('GET');
+  });
+
+  it('빈_목록이면_안내_문구를_렌더한다', async () => {
+    mockFetchSequence([{ status: 200, body: listBody() }]);
+    await act(async () => {
+      renderListPage();
+    });
+    await flush();
+    expect(screen.getByText(/아직 글이 없습니다/)).toBeTruthy();
+  });
+
+  it('글_제목_링크를_클릭하면_상세로_라우팅한다', async () => {
+    mockFetchSequence([
+      {
+        status: 200,
+        body: listBody({ content: [samplePost(7, { title: 'hello world' })], totalElements: 1, totalPages: 1 }),
+      },
+    ]);
+    await act(async () => {
+      renderListPage();
+    });
+    await flush();
+    await act(async () => {
+      fireEvent.click(screen.getByRole('link', { name: /hello world/ }));
+    });
+    expect(currentPath).toBe('/posts/7');
+  });
+
+  it('글쓰기_버튼은_/posts/new_링크다', async () => {
+    mockFetchSequence([{ status: 200, body: listBody() }]);
+    await act(async () => {
+      renderListPage();
+    });
+    await flush();
+    const link = screen.getByRole('link', { name: /글쓰기/ }) as HTMLAnchorElement;
+    await act(async () => {
+      fireEvent.click(link);
+    });
+    expect(currentPath).toBe('/posts/new');
+  });
+
+  it('다음_페이지_버튼_클릭_시_page1_을_요청한다', async () => {
+    const fn = mockFetchSequence([
+      { status: 200, body: listBody({ content: [samplePost(1)], totalElements: 25, totalPages: 3 }) },
+      { status: 200, body: listBody({ content: [samplePost(11)], page: 1, totalElements: 25, totalPages: 3 }) },
+    ]);
+    await act(async () => {
+      renderListPage();
+    });
+    await flush();
+    await act(async () => {
+      fireEvent.click(screen.getByRole('button', { name: /다음/ }));
+    });
+    await flush();
+    expect(fn).toHaveBeenCalledTimes(2);
+    const [url] = fn.mock.calls[1] as [string, RequestInit | undefined];
+    expect(url).toBe('/api/posts?page=1&size=10');
+  });
+
+  it('마지막_페이지에서는_다음_버튼이_disabled_다', async () => {
+    mockFetchSequence([
+      { status: 200, body: listBody({ content: [samplePost(1)], totalElements: 5, totalPages: 1 }) },
+    ]);
+    await act(async () => {
+      renderListPage();
+    });
+    await flush();
+    const next = screen.getByRole('button', { name: /다음/ }) as HTMLButtonElement;
+    expect(next.disabled).toBe(true);
+  });
+
+  it('첫_페이지에서는_이전_버튼이_disabled_다', async () => {
+    mockFetchSequence([
+      { status: 200, body: listBody({ content: [samplePost(1)], totalElements: 25, totalPages: 3 }) },
+    ]);
+    await act(async () => {
+      renderListPage();
+    });
+    await flush();
+    const prev = screen.getByRole('button', { name: /이전/ }) as HTMLButtonElement;
+    expect(prev.disabled).toBe(true);
+  });
+
+  it('500_응답이면_에러_배너와_재시도_버튼이_뜬다', async () => {
+    const fn = mockFetchSequence([
+      { status: 500, body: { status: 500, error: 'Internal', message: '서버 오류', path: '/api/posts', timestamp: '' } },
+      { status: 200, body: listBody({ content: [samplePost(1)], totalElements: 1, totalPages: 1 }) },
+    ]);
+    await act(async () => {
+      renderListPage();
+    });
+    await flush();
+    expect(screen.getByText(/서버 오류/)).toBeTruthy();
+    await act(async () => {
+      fireEvent.click(screen.getByRole('button', { name: /재시도/ }));
+    });
+    await flush();
+    expect(fn).toHaveBeenCalledTimes(2);
+    expect(screen.getByText(/글 1/)).toBeTruthy();
+  });
+});

--- a/frontend/src/pages/PostListPage.tsx
+++ b/frontend/src/pages/PostListPage.tsx
@@ -1,0 +1,48 @@
+import { useCallback, useEffect, useState } from 'react';
+import { listPosts, PostError, type PostPageResponse } from '../api/posts';
+import { PostList } from '../components/posts/PostList';
+
+const FALLBACK_ERROR = '게시글을 불러오지 못했습니다';
+
+export default function PostListPage() {
+  const [page, setPage] = useState(0);
+  const [data, setData] = useState<PostPageResponse | null>(null);
+  const [loading, setLoading] = useState(false);
+  const [error, setError] = useState<string | null>(null);
+
+  const load = useCallback((p: number) => {
+    setLoading(true);
+    setError(null);
+    listPosts(p, 10)
+      .then((res) => {
+        setData(res);
+        setPage(res.page);
+      })
+      .catch((e) => {
+        if (e instanceof PostError) setError(e.message || FALLBACK_ERROR);
+        else setError(FALLBACK_ERROR);
+      })
+      .finally(() => setLoading(false));
+  }, []);
+
+  useEffect(() => {
+    load(0);
+  }, [load]);
+
+  const onPrev = () => load(Math.max(0, page - 1));
+  const onNext = () => load(page + 1);
+  const onRetry = () => load(page);
+
+  return (
+    <PostList
+      posts={data?.content ?? []}
+      loading={loading}
+      error={error}
+      page={page}
+      totalPages={data?.totalPages ?? 0}
+      onPrev={onPrev}
+      onNext={onNext}
+      onRetry={onRetry}
+    />
+  );
+}

--- a/frontend/src/pages/PostNewPage.test.tsx
+++ b/frontend/src/pages/PostNewPage.test.tsx
@@ -1,0 +1,215 @@
+import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest';
+import { act, cleanup, fireEvent, render, screen } from '@testing-library/react';
+import { MemoryRouter, Route, Routes, useLocation } from 'react-router-dom';
+import PostNewPage from './PostNewPage';
+import * as tokenStore from '../auth/tokenStore';
+
+afterEach(() => {
+  cleanup();
+  vi.restoreAllMocks();
+  tokenStore.clear();
+});
+
+beforeEach(() => {
+  delete (globalThis as { fetch?: typeof fetch }).fetch;
+  tokenStore.clear();
+});
+
+interface MockResponse {
+  status: number;
+  body: unknown;
+}
+
+function mockFetchSequence(responses: MockResponse[]) {
+  let i = 0;
+  const fn = vi.fn(() => {
+    const r = responses[Math.min(i, responses.length - 1)];
+    i += 1;
+    return Promise.resolve({
+      ok: r.status >= 200 && r.status < 300,
+      status: r.status,
+      json: async () => r.body,
+    } as Response);
+  });
+  globalThis.fetch = fn as unknown as typeof fetch;
+  return fn;
+}
+
+let currentPath: string | null = null;
+function LocationSpy() {
+  const loc = useLocation();
+  currentPath = loc.pathname;
+  return null;
+}
+
+function renderNewPage() {
+  currentPath = null;
+  return render(
+    <MemoryRouter initialEntries={['/posts/new']}>
+      <Routes>
+        <Route path="/posts/new" element={<PostNewPage />} />
+        <Route path="/posts/:id" element={<div data-testid="detail" />} />
+        <Route path="/login" element={<div data-testid="login">LOGIN</div>} />
+      </Routes>
+      <LocationSpy />
+    </MemoryRouter>,
+  );
+}
+
+function fill(title: string, content: string) {
+  fireEvent.change(screen.getByLabelText(/^title$/i), { target: { value: title } });
+  fireEvent.change(screen.getByLabelText(/^content$/i), { target: { value: content } });
+}
+
+async function clickSubmit(name: RegExp = /^등록$/) {
+  await act(async () => {
+    fireEvent.click(screen.getByRole('button', { name }));
+  });
+}
+
+const errorBody = (status: number, message: string) => ({
+  status,
+  error: 'Error',
+  message,
+  path: '/api/posts',
+  timestamp: '2026-04-28T00:00:00Z',
+});
+
+const created = (id: number, title: string, content: string) => ({
+  id,
+  title,
+  content,
+  authorUsername: 'marco',
+  createdAt: '2026-04-28T00:00:00Z',
+  updatedAt: '2026-04-28T00:00:00Z',
+});
+
+async function flush() {
+  await act(async () => {
+    await Promise.resolve();
+    await Promise.resolve();
+  });
+}
+
+describe('PostNewPage', () => {
+  it('비로그인_상태에서_/posts/new_접근_시_/login_으로_redirect_한다', () => {
+    renderNewPage();
+    expect(currentPath).toBe('/login');
+  });
+
+  it('정상_제출이면_POST_/api/posts_를_Bearer_헤더와_함께_호출한다', async () => {
+    tokenStore.set('t.k.n');
+    const fn = mockFetchSequence([{ status: 201, body: created(11, '새 글', '본문') }]);
+    renderNewPage();
+    fill('새 글', '본문');
+    await clickSubmit();
+    await flush();
+    expect(fn).toHaveBeenCalledTimes(1);
+    const [url, init] = fn.mock.calls[0] as [string, RequestInit];
+    expect(url).toBe('/api/posts');
+    expect(init.method).toBe('POST');
+    const headers = init.headers as Record<string, string>;
+    expect(headers['Content-Type']).toBe('application/json');
+    expect(headers.Authorization).toBe('Bearer t.k.n');
+    expect(JSON.parse(init.body as string)).toEqual({ title: '새 글', content: '본문' });
+  });
+
+  it('201_응답_시_/posts/:id_로_네비게이트한다', async () => {
+    tokenStore.set('t.k.n');
+    mockFetchSequence([{ status: 201, body: created(11, '새 글', '본문') }]);
+    renderNewPage();
+    fill('새 글', '본문');
+    await clickSubmit();
+    await flush();
+    expect(currentPath).toBe('/posts/11');
+  });
+
+  it('title이_빈_값이면_검증_메시지가_뜨고_API는_호출되지_않는다', async () => {
+    tokenStore.set('t.k.n');
+    const fn = vi.fn();
+    globalThis.fetch = fn as unknown as typeof fetch;
+    renderNewPage();
+    fill('', '본문');
+    await clickSubmit();
+    expect(fn).not.toHaveBeenCalled();
+    expect(screen.getByText(/title은 필수입니다/)).toBeTruthy();
+  });
+
+  it('title이_공백만이면_검증_메시지가_뜬다', async () => {
+    tokenStore.set('t.k.n');
+    const fn = vi.fn();
+    globalThis.fetch = fn as unknown as typeof fetch;
+    renderNewPage();
+    fill('   ', '본문');
+    await clickSubmit();
+    expect(fn).not.toHaveBeenCalled();
+    expect(screen.getByText(/title은 필수입니다/)).toBeTruthy();
+  });
+
+  it('title이_101자이면_검증_메시지가_뜬다', async () => {
+    tokenStore.set('t.k.n');
+    const fn = vi.fn();
+    globalThis.fetch = fn as unknown as typeof fetch;
+    renderNewPage();
+    fill('a'.repeat(101), '본문');
+    await clickSubmit();
+    expect(fn).not.toHaveBeenCalled();
+    expect(screen.getByText(/title은 최대 100자입니다/)).toBeTruthy();
+  });
+
+  it('content가_빈_값이면_검증_메시지가_뜬다', async () => {
+    tokenStore.set('t.k.n');
+    const fn = vi.fn();
+    globalThis.fetch = fn as unknown as typeof fetch;
+    renderNewPage();
+    fill('제목', '');
+    await clickSubmit();
+    expect(fn).not.toHaveBeenCalled();
+    expect(screen.getByText(/content는 필수입니다/)).toBeTruthy();
+  });
+
+  it('400_응답_시_서버_message를_렌더한다', async () => {
+    tokenStore.set('t.k.n');
+    mockFetchSequence([{ status: 400, body: errorBody(400, 'title: title은 최대 100자입니다') }]);
+    renderNewPage();
+    fill('제목', '본문');
+    await clickSubmit();
+    await flush();
+    expect(screen.getByText(/title은 최대 100자입니다/)).toBeTruthy();
+    expect(currentPath).toBe('/posts/new');
+  });
+
+  it('401_응답_시_/login_으로_redirect_한다_만료_토큰', async () => {
+    tokenStore.set('expired');
+    mockFetchSequence([{ status: 401, body: errorBody(401, '인증이 필요합니다') }]);
+    renderNewPage();
+    fill('제목', '본문');
+    await clickSubmit();
+    await flush();
+    expect(currentPath).toBe('/login');
+  });
+
+  it('제출_중에는_버튼이_disabled_이다', async () => {
+    tokenStore.set('t.k.n');
+    let resolveFetch: (value: Response) => void = () => {};
+    const pending = new Promise<Response>((resolve) => {
+      resolveFetch = resolve;
+    });
+    globalThis.fetch = vi.fn(() => pending) as unknown as typeof fetch;
+    renderNewPage();
+    fill('제목', '본문');
+    await act(async () => {
+      fireEvent.click(screen.getByRole('button', { name: /^등록$/ }));
+    });
+    const button = screen.getByRole('button', { name: /등록 중/ }) as HTMLButtonElement;
+    expect(button.disabled).toBe(true);
+    await act(async () => {
+      resolveFetch({
+        ok: true,
+        status: 201,
+        json: async () => created(11, '제목', '본문'),
+      } as Response);
+      await pending;
+    });
+  });
+});

--- a/frontend/src/pages/PostNewPage.tsx
+++ b/frontend/src/pages/PostNewPage.tsx
@@ -1,0 +1,78 @@
+import { useState } from 'react';
+import { Navigate, useNavigate } from 'react-router-dom';
+import { createPost, PostError } from '../api/posts';
+import * as tokenStore from '../auth/tokenStore';
+import { PostForm, type PostFormField } from '../components/posts/PostForm';
+
+const FALLBACK_ERROR = '요청을 처리하지 못했습니다';
+
+function validate(title: string, content: string): Partial<Record<PostFormField, string>> {
+  const errors: Partial<Record<PostFormField, string>> = {};
+  if (title.trim().length === 0) errors.title = 'title은 필수입니다';
+  else if (title.length > 100) errors.title = 'title은 최대 100자입니다';
+  if (content.length === 0) errors.content = 'content는 필수입니다';
+  return errors;
+}
+
+export default function PostNewPage() {
+  const navigate = useNavigate();
+  const [title, setTitle] = useState('');
+  const [content, setContent] = useState('');
+  const [submitting, setSubmitting] = useState(false);
+  const [error, setError] = useState<string | null>(null);
+  const [fieldErrors, setFieldErrors] = useState<Partial<Record<PostFormField, string>>>({});
+
+  if (tokenStore.get() === null) {
+    return <Navigate to="/login" replace />;
+  }
+
+  const onChange = (field: PostFormField, value: string) => {
+    if (field === 'title') setTitle(value);
+    else setContent(value);
+    setFieldErrors((prev) => {
+      if (!prev[field]) return prev;
+      const next = { ...prev };
+      delete next[field];
+      return next;
+    });
+    if (error) setError(null);
+  };
+
+  const onSubmit = async () => {
+    const errors = validate(title, content);
+    if (Object.keys(errors).length > 0) {
+      setFieldErrors(errors);
+      return;
+    }
+    setFieldErrors({});
+    setError(null);
+    setSubmitting(true);
+    try {
+      const created = await createPost({ title: title.trim(), content });
+      navigate(`/posts/${created.id}`);
+    } catch (e) {
+      if (e instanceof PostError && e.status === 401) {
+        tokenStore.clear();
+        navigate('/login');
+        return;
+      }
+      if (e instanceof PostError) setError(e.message || FALLBACK_ERROR);
+      else setError(FALLBACK_ERROR);
+    } finally {
+      setSubmitting(false);
+    }
+  };
+
+  return (
+    <PostForm
+      mode="create"
+      title={title}
+      content={content}
+      onChange={onChange}
+      onSubmit={onSubmit}
+      submitting={submitting}
+      error={error}
+      fieldErrors={fieldErrors}
+    />
+  );
+}

--- a/src/test/java/com/example/board/post/PostBoardPlaywrightTest.java
+++ b/src/test/java/com/example/board/post/PostBoardPlaywrightTest.java
@@ -1,7 +1,9 @@
-package com.example.board.user;
+package com.example.board.post;
 
 import static org.assertj.core.api.Assertions.assertThat;
 
+import com.example.board.user.AuthService;
+import com.example.board.user.SignupRequest;
 import com.microsoft.playwright.Browser;
 import com.microsoft.playwright.BrowserType;
 import com.microsoft.playwright.Page;
@@ -17,66 +19,73 @@ import org.springframework.test.context.ActiveProfiles;
 @SpringBootTest(webEnvironment = SpringBootTest.WebEnvironment.RANDOM_PORT)
 @ActiveProfiles("test")
 @Tag("playwright")
-class LoginPlaywrightTest {
+class PostBoardPlaywrightTest {
 
   @LocalServerPort int port;
 
   @Autowired AuthService authService;
 
   @Test
-  void 브라우저로_로그인_성공시_홈으로_이동한다() {
-    String username = "pwl" + (System.currentTimeMillis() % 1_000_000_000L);
+  void 브라우저로_로그인_후_글_작성_수정_삭제까지_한_흐름이_동작한다() {
+    String username = "pwb" + (System.currentTimeMillis() % 1_000_000_000L);
     String password = "pw12345playwright";
     authService.signup(new SignupRequest(username, password));
+
+    String original = "Playwright 작성글 " + System.nanoTime();
+    String edited = original + " (수정됨)";
 
     try (Playwright playwright = Playwright.create()) {
       Browser browser =
           playwright.chromium().launch(new BrowserType.LaunchOptions().setHeadless(true));
       try {
         Page page = browser.newPage();
-        page.navigate("http://localhost:" + port + "/login");
 
+        // 1) 로그인
+        page.navigate("http://localhost:" + port + "/login");
         page.waitForSelector(
             "#username", new Page.WaitForSelectorOptions().setState(WaitForSelectorState.VISIBLE));
         page.fill("#username", username);
         page.fill("#password", password);
         page.click("button[type=submit]");
 
+        // 2) 목록 진입 — "게시판" 헤딩 가시
         page.waitForSelector(
             "text=게시판",
             new Page.WaitForSelectorOptions().setState(WaitForSelectorState.VISIBLE));
-
         assertThat(page.url()).doesNotContain("/login");
-      } finally {
-        browser.close();
-      }
-    }
-  }
 
-  @Test
-  void 브라우저로_잘못된_비밀번호_로그인시_고정_오류_메시지가_표시된다() {
-    String username = "pwlbad" + (System.currentTimeMillis() % 1_000_000_000L);
-    authService.signup(new SignupRequest(username, "correctpassword"));
-
-    try (Playwright playwright = Playwright.create()) {
-      Browser browser =
-          playwright.chromium().launch(new BrowserType.LaunchOptions().setHeadless(true));
-      try {
-        Page page = browser.newPage();
-        page.navigate("http://localhost:" + port + "/login");
-
+        // 3) 글쓰기
+        page.click("text=글쓰기");
         page.waitForSelector(
-            "#username", new Page.WaitForSelectorOptions().setState(WaitForSelectorState.VISIBLE));
-        page.fill("#username", username);
-        page.fill("#password", "wrongpassword");
+            "#title", new Page.WaitForSelectorOptions().setState(WaitForSelectorState.VISIBLE));
+        page.fill("#title", original);
+        page.fill("#content", "Playwright 본문\n첫 글");
         page.click("button[type=submit]");
 
+        // 4) 상세에서 작성 글 가시
         page.waitForSelector(
-            "text=username과 password가 일치하지 않습니다",
+            "text=" + original,
+            new Page.WaitForSelectorOptions().setState(WaitForSelectorState.VISIBLE));
+        assertThat(page.url()).matches(".*/posts/\\d+$");
+
+        // 5) 수정
+        page.click("text=수정");
+        page.waitForSelector(
+            "#title", new Page.WaitForSelectorOptions().setState(WaitForSelectorState.VISIBLE));
+        page.fill("#title", edited);
+        page.click("button[type=submit]");
+        page.waitForSelector(
+            "text=" + edited,
             new Page.WaitForSelectorOptions().setState(WaitForSelectorState.VISIBLE));
 
-        assertThat(page.content()).contains("username과 password가 일치하지 않습니다");
-        assertThat(page.url()).endsWith("/login");
+        // 6) 삭제 — confirm 자동 수락
+        page.onceDialog(dialog -> dialog.accept());
+        page.click("text=삭제");
+        page.waitForSelector(
+            "text=게시판",
+            new Page.WaitForSelectorOptions().setState(WaitForSelectorState.VISIBLE));
+        assertThat(page.url()).endsWith("/");
+        assertThat(page.content()).doesNotContain(edited);
       } finally {
         browser.close();
       }

--- a/src/test/java/com/example/board/post/PostBoardPlaywrightTest.java
+++ b/src/test/java/com/example/board/post/PostBoardPlaywrightTest.java
@@ -50,8 +50,7 @@ class PostBoardPlaywrightTest {
 
         // 2) 목록 진입 — "게시판" 헤딩 가시
         page.waitForSelector(
-            "text=게시판",
-            new Page.WaitForSelectorOptions().setState(WaitForSelectorState.VISIBLE));
+            "text=게시판", new Page.WaitForSelectorOptions().setState(WaitForSelectorState.VISIBLE));
         assertThat(page.url()).doesNotContain("/login");
 
         // 3) 글쓰기
@@ -82,8 +81,7 @@ class PostBoardPlaywrightTest {
         page.onceDialog(dialog -> dialog.accept());
         page.click("text=삭제");
         page.waitForSelector(
-            "text=게시판",
-            new Page.WaitForSelectorOptions().setState(WaitForSelectorState.VISIBLE));
+            "text=게시판", new Page.WaitForSelectorOptions().setState(WaitForSelectorState.VISIBLE));
         assertThat(page.url()).endsWith("/");
         assertThat(page.content()).doesNotContain(edited);
       } finally {

--- a/src/test/java/com/example/board/user/LoginPlaywrightTest.java
+++ b/src/test/java/com/example/board/user/LoginPlaywrightTest.java
@@ -43,8 +43,7 @@ class LoginPlaywrightTest {
         page.click("button[type=submit]");
 
         page.waitForSelector(
-            "text=게시판",
-            new Page.WaitForSelectorOptions().setState(WaitForSelectorState.VISIBLE));
+            "text=게시판", new Page.WaitForSelectorOptions().setState(WaitForSelectorState.VISIBLE));
 
         assertThat(page.url()).doesNotContain("/login");
       } finally {


### PR DESCRIPTION
## Summary
- 게시글 CRUD를 위한 React 페이지 4종(목록·상세·작성·수정) 추가, `/`를 게시판으로 전환
- `frontend/src/api/posts.ts` — `tokenStore`에서 자동으로 `Authorization: Bearer ...` 첨부, `PostError` 클래스로 4xx/5xx 분기
- 디자인은 `auth-edit-*` editorial 토큰을 작성·수정 폼에 그대로 재활용, 목록·상세는 `postStyles.ts` (Source Serif Pro 헤딩, `#f6f4ef` 배경)로 일관 톤 유지
- 인증 가드: `/posts/new`·`/posts/:id/edit` 진입 시 `tokenStore` 비어있으면 `<Navigate to=\"/login\" />`. 제출 중 401 응답이면 토큰 비우고 `/login` redirect
- Closes #45

## Test plan
- [x] `cd frontend && npm test` — Vitest 7 files / 58 tests 통과 (신규 4 files / 34 tests + 기존 24)
- [ ] `./gradlew test` — 백엔드 컴파일·단위 테스트 (로컬에서 확인 필요. 본 리포 작업 환경에 JDK 미설치)
- [ ] `./gradlew test -PincludePlaywright --tests '*PostBoardPlaywrightTest'` — signup → login → 작성 → 상세 → 수정 → 삭제 한 흐름
- [ ] `./gradlew bootRun` 후 http://localhost:8080 진입 → 로그인 → 글쓰기 → 본인 글 수정·삭제 시각 확인 (auth-edit-* 디자인 톤 일치)
- [ ] `(cd frontend && npm run storybook)` — `Posts/PostForm` 스토리 6종(Create/Update × Idle/Submitting/FieldError/ServerError/Forbidden) 시각 검수

## 주의 / 예외 사유
- **수정 파일 17개로 이슈 한도(≤10) 초과**. 사유: 게시판 CRUD는 단일 라이프사이클 단위(목록·상세·작성·수정·삭제)로 묶어야 의미가 있고, 분할 시 두 PR이 같은 `posts.ts`/`postStyles.ts`/`App.tsx`를 건드려 충돌·문맥 분산이 큼. #31(13개), #32(14개)와 같은 운영상 예외 선례. 이슈 #45 본문에도 명시.
- **`LoginPlaywrightTest`의 `text=React OK` 셀렉터 갱신** 1건이 같이 들어감. `/`의 placeholder가 PostListPage로 교체되면서 기존 셀렉터가 깨짐 — 같은 PR에서 `text=게시판`으로 갱신해야 양쪽이 같은 시점에 PASS.
- 작성자 == 현재 사용자 판별을 위한 `/api/auth/me` 부재 → 토큰 존재 시 수정·삭제 버튼 노출, 클릭 후 403 시 메시지 처리로 단순화. 후속 이슈에서 me API 도입 검토.
- tokenStore는 메모리 only 유지 (영속화는 #28).

🤖 Generated with [Claude Code](https://claude.com/claude-code)